### PR TITLE
Shop item: use text/x-html-safe output format and only allow text/html input.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- Shop item: use text/x-html-safe output format and only allow text/html input.
+  [jone]
+
 - Plone 4.3 compatibility: fix imports.
   [jone]
 

--- a/ftw/shop/content/shopitem.py
+++ b/ftw/shop/content/shopitem.py
@@ -36,6 +36,10 @@ ShopItemSchema = ATContentTypeSchema.copy() + atapi.Schema((
             searchable=True,
             primary=True,
             storage=atapi.AnnotationStorage(migrate=True),
+            allowable_content_types=('text/html', ),
+            default_content_type='text/html',
+            validators=('isTidyHtmlWithCleanup', ),
+            default_input_type='text/html',
             default_output_type='text/x-html-safe',
             widget=atapi.RichWidget(
                 description='',


### PR DESCRIPTION
- Add validator and use `text/x-html-safe` output format for preventing XSS
- Use only `text/html` as allowable content types, so that the format is not selectable in the WYSIWYG field

/cc @maethu
