### PR TITLE
Remove permission "Add Order"

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove unused permission "ftw.shop: Add Order".
+  [jone]
 
 
 1.2 (2013-05-28)

--- a/ftw/shop/__init__.py
+++ b/ftw/shop/__init__.py
@@ -13,10 +13,6 @@ from ftw.shop import config
 
 shopMessageFactory = MessageFactory('ftw.shop')
 
-# Needed for Plone 3 compatibility
-from Products.CMFCore.permissions import setDefaultRoles
-setDefaultRoles("ftw.shop: Add Order", ('Manager',))
-
 
 def initialize(context):
     """Initializer called when used as a Zope 2 product.

--- a/ftw/shop/configure.zcml
+++ b/ftw/shop/configure.zcml
@@ -16,10 +16,6 @@
      id="ftw.shop.AddShopItem"
      title="ftw.shop: Add Shop Item"
      />
-    <permission
-     id="ftw.shop.AddOrder"
-     title="ftw.shop: Add Order"
-     />
 
     <permission
         id="ftw.shop.AddSupplier"

--- a/ftw/shop/lawgiver.zcml
+++ b/ftw/shop/lawgiver.zcml
@@ -12,9 +12,4 @@
                      ftw.shop: Add Supplier"
         />
 
-    <lawgiver:map_permissions
-        action_group="manage"
-        permissions="ftw.shop: Add Order"
-        />
-
 </configure>

--- a/ftw/shop/profiles/default/rolemap.xml
+++ b/ftw/shop/profiles/default/rolemap.xml
@@ -10,9 +10,6 @@
       <role name="Manager" />
       <role name="Contributor" />
     </permission>
-    <permission name="ftw.shop: Add Order" acquire="False">
-      <role name="Manager" />
-    </permission>
     <permission name="ftw.shop: Add Supplier" acquire="False">
       <role name="Manager" />
       <role name="Contributor" />

--- a/ftw/shop/tests/test_setup.py
+++ b/ftw/shop/tests/test_setup.py
@@ -1,12 +1,11 @@
 import unittest
-from Products.CMFCore.utils import getToolByName
 import zope.event
 from Products.Archetypes.event import ObjectInitializedEvent
 from ftw.shop.tests.base import FtwShopTestCase
 
 
 class TestSetup(FtwShopTestCase):
-    
+
     def afterSetUp(self):
         super(TestSetup, self).afterSetUp()
 
@@ -15,18 +14,15 @@ class TestSetup(FtwShopTestCase):
         # closely up in the permission management screen's user interface
         roles = ['Manager', 'Contributor']
         for r in roles:
-            selected_permissions = [p['name'] for p in 
+            selected_permissions = [p['name'] for p in
                                     self.portal.permissionsOfRole(r) if p['selected']]
             self.failUnless('ftw.shop: Add Shop Item' in selected_permissions)
             self.failUnless('ftw.shop: Add Shop Category' in selected_permissions)
-            if r == 'Manager':
-                self.failUnless('ftw.shop: Add Order' in selected_permissions)
 
-            
     def test_shop_types_installed(self):
         self.failUnless('ShopCategory' in self.types.objectIds())
         self.failUnless('ShopItem' in self.types.objectIds())
-        
+
     def test_shop_category_fti(self):
         document_fti = getattr(self.types, 'ShopCategory')
         self.failUnless(document_fti.global_allow)
@@ -47,7 +43,7 @@ class TestSetup(FtwShopTestCase):
 
         event = ObjectInitializedEvent(item, self.portal.REQUEST)
         zope.event.notify(event)
-        
+
         self.failUnless(self.portal.shop.products in item.listCategories())
 
 


### PR DESCRIPTION
I tried to figure out what the permission `ftw.shop: Add Order` does (because I wanted to change the lawgiver action group mapping) – but I couldn't find out.

My grep says:

``` shell
projects/packages/ftw.shop[master]% git grep 'ftw.shop: Add Order'                                                                                                  jone4tw.local
ftw/shop/__init__.py:setDefaultRoles("ftw.shop: Add Order", ('Manager',))
ftw/shop/configure.zcml:     title="ftw.shop: Add Order"
ftw/shop/lawgiver.zcml:        permissions="ftw.shop: Add Order"
ftw/shop/profiles/default/rolemap.xml:    <permission name="ftw.shop: Add Order" acquire="False">
ftw/shop/tests/test_setup.py:                self.failUnless('ftw.shop: Add Order' in selected_permissions)
```

The `__init__.py`, `configure.zcml`, `lawgiver.zcml` and `rolemap.xml` are permission setups and `test_setup.py` tests some parts of those.
But it seems not to be used at all !?

@lukasgraf can we remove this?
