### PR TITLE
Automatically set the shop root on the portal upon new installation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,20 +47,13 @@ Installation
 Configuration
 ============
 
-After you installed ``ftw.shop`` on your Plone site, you need to create a shop
-root. This needs to be a folderish container that provides the marker interface
-``IShopRoot``. This is where you will add your ShopCategory and ShopItem objects.
+When installing ``ftw.shop``, the Plone site is automatically configured as
+shop root (``IShopRoot`` interface).
+If you'd like another container to be the shop root you can change this by
+removing the ``IShopRoot`` from the Plone site and let another container
+provide it.
 
-You can either do this yourself, by adding an ATFolder anywhere you like, and
-use the ZMI "Interfaces" tab to make it provide the ``IShopRoot`` interface.
-
-The easier alternative is using the ``initialize-shop-structure`` view on the
-Plone site root. Simply visit
-
-http://localhost:8080/Plone/initialize-shop-structure
-
-and it will create an ATFolder named ``'shop'`` at the top level of your Plone
-site and make it provide the ``IShopRoot`` interface.
+You might also want to add a shop cart portlet.
 
 After that, most configuration can be done through the "Shop configuration"
 control panel.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Automatically set the shop root on the portal upon new installation. #15
+  [jone]
+
 - Update German translations.
   [jone]
 

--- a/ftw/shop/setuphandlers.py
+++ b/ftw/shop/setuphandlers.py
@@ -1,5 +1,8 @@
-import logging
 from Products.CMFCore.utils import getToolByName
+from ftw.shop.interfaces import IShopRoot
+from zope.interface import alsoProvides
+import logging
+
 
 # The profile id of our package:
 PROFILE_ID = 'profile-ftw.shop:default'
@@ -52,6 +55,12 @@ def add_catalog_indexes(context, logger=None):
         catalog.manage_reindexIndex(ids=indexables)
 
 
+def set_shop_root(site):
+    """Lets the plone site provide the IShopRoot interface.
+    """
+    alsoProvides(site, IShopRoot)
+
+
 def import_various(context):
     """Import step for configuration that is not handled in xml files.
     """
@@ -61,3 +70,4 @@ def import_various(context):
     logger = context.getLogger('ftw.shop')
     site = context.getSite()
     add_catalog_indexes(site, logger)
+    set_shop_root(site)

--- a/ftw/shop/tests/test_browser_cart.py
+++ b/ftw/shop/tests/test_browser_cart.py
@@ -1,6 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.shop.interfaces import IShopRoot
 from ftw.shop.testing import FTW_SHOP_FUNCTIONAL_TESTING
 from ftw.shop.tests.pages import cartportlet
 from ftw.shop.tests.pages import shopitem
@@ -11,7 +10,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from unittest2 import TestCase
-from zope.interface import alsoProvides
 import transaction
 
 
@@ -24,7 +22,6 @@ class TestBrowserCart(TestCase):
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
 
-        alsoProvides(portal, IShopRoot)
         create(Builder('cart portlet'))
         transaction.commit()
 

--- a/ftw/shop/tests/test_browser_checkout.py
+++ b/ftw/shop/tests/test_browser_checkout.py
@@ -1,6 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.shop.interfaces import IShopRoot
 from ftw.shop.testing import FTW_SHOP_FUNCTIONAL_TESTING
 from ftw.shop.tests.pages import cartportlet
 from ftw.shop.tests.pages import checkout
@@ -13,7 +12,6 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import login
 from plone.app.testing import setRoles
 from unittest2 import TestCase
-from zope.interface import alsoProvides
 import transaction
 
 
@@ -26,7 +24,6 @@ class TestBrowserCheckout(TestCase):
         setRoles(portal, TEST_USER_ID, ['Manager'])
         login(portal, TEST_USER_NAME)
 
-        alsoProvides(portal, IShopRoot)
         create(Builder('cart portlet'))
         Mailing(portal).set_up()
         transaction.commit()


### PR DESCRIPTION
Changes the shop setup to automatically configure the Plone site as shop root, as discussed in #15.
I've also removed note about `initialize-shop-structure` from the readme, since this is not exactly required anymore.

@lukasgraf thoughts?
