### PR TITLE
Javascript: replace jq with jQuery / $ for Plone 4.3 compatibility.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Javascript: replace jq with jQuery / $ for Plone 4.3 compatibility.
+  [jone]
+
 - Make phone number in customer confirmation mail configurable and optional.
   [jone]
 

--- a/ftw/shop/browser/resources/contactform_prefill.js
+++ b/ftw/shop/browser/resources/contactform_prefill.js
@@ -1,32 +1,32 @@
-jq(function () {
+jQuery(function ($) {
     // Load contact info depending on personnel no.
-    jq('input#contact_information-widgets-personnel_no').blur(function (event) {
+    $('input#contact_information-widgets-personnel_no').blur(function (event) {
         // Do something here
     });
 
 
     // Grey-out address field unless "Different from invoice address" is checked
-    jq('input#shipping_address-widgets-used-0').click(function (event) {
-        var state = !(jq(this).attr('checked'));
+    $('input#shipping_address-widgets-used-0').click(function (event) {
+        var state = !($(this).attr('checked'));
         toggle_fields(state);
     });
 
     var toggle_fields = function (state) {
-        var fields = jq('#wizard-step-shipping_address input')
+        var fields = $('#wizard-step-shipping_address input')
                      .not('input#shipping_address-widgets-used-0')
                      .not('.submit-widget');
         fields.each(function () {
-            jq(this).attr("readonly", state);
+            $(this).attr("readonly", state);
             if (state == true) {
-                jq(this).addClass("greyed-out");
+                $(this).addClass("greyed-out");
             }
             else {
-                jq(this).removeClass("greyed-out");
+                $(this).removeClass("greyed-out");
             }
         });
     };
 
     // Set initial state of fields on page load
-    toggle_fields(!(jq('input#shipping_address-widgets-used-0').attr('checked')));
+    toggle_fields(!($('input#shipping_address-widgets-used-0').attr('checked')));
 
 });

--- a/ftw/shop/browser/resources/edit_variations.js
+++ b/ftw/shop/browser/resources/edit_variations.js
@@ -1,72 +1,72 @@
-jq(function () {
+jQuery(function ($) {
     // toggle
-    jq("#content dl.toggleVariation dt").click(function () {
-        jq(this).next().slideToggle();
+    $("#content dl.toggleVariation dt").click(function () {
+        $(this).next().slideToggle();
     });
 
     var update_vcodes = function () {
         // Updates all vcodes in the inputs name attributes
-        jq('.varTable').each(function(tbl_idx, tbl) {
-            var rows = jq(tbl).find('tr');
+        $('.varTable').each(function(tbl_idx, tbl) {
+            var rows = $(tbl).find('tr');
             rows.each(function(row_idx, row) {
                 var vcode = tbl_idx + '-' + (row_idx - 1)
-                var inputs = jq(row).find('input');
+                var inputs = $(row).find('input');
                 inputs.each(function() {
-                    if (jq(this).hasClass('attributeLabelInput')) {
+                    if ($(this).hasClass('attributeLabelInput')) {
                         var new_name = "v2-value-" + (row_idx - 1);
                     }
                     else {
-                        var old_name = jq(this).attr('name');
+                        var old_name = $(this).attr('name');
                         var old_v1idx = old_name.split('-')[1];
                         var old_v2idx = old_name.split('-')[2];
                         var old_vcode = old_v1idx + '-' + old_v2idx;
                         var new_name = old_name.replace(old_vcode, vcode);
                     }
-                    jq(this).attr('name', new_name);
+                    $(this).attr('name', new_name);
                 });
             });
         });
     };
 
       // Add a new attribute
-      jq('.add-attribute').live('click', function(event) {
-          var attr_template = jq('.attribute-template');
+      $('.add-attribute').live('click', function(event) {
+          var attr_template = $('.attribute-template');
           attr_template.removeClass('attribute-template');
           attr_template.addClass('attribute');
           attr_template.css('display', 'block');
       });
 
       // Toggle disabled status of the row's input fields
-      jq('.varActiveCheckbox').live('click', function(event) {
-          var row = jq(this).parents('tr');
+      $('.varActiveCheckbox').live('click', function(event) {
+          var row = $(this).parents('tr');
           row.find('input').not('.varActiveCheckbox').not('.attributeLabelInput').each(function() {
-              var current_val = jq(this).attr('disabled');
+              var current_val = $(this).attr('disabled');
               if (current_val === true) {
-                  jq(this).removeAttr('disabled');
+                  $(this).removeAttr('disabled');
               }
               else {
-                  jq(this).attr('disabled', true);
+                  $(this).attr('disabled', true);
               }
           });
           row.toggleClass('greyed-out');
       });
 
       // Add a new variant
-      jq('.add-variant').live('click', function(event) {
-          var clicked_row = jq(this).parents('tr');
+      $('.add-variant').live('click', function(event) {
+          var clicked_row = $(this).parents('tr');
           var vcode = clicked_row.find('input').first().attr('name').replace('-active:boolean', '').replace('var-', '');
           var v1_idx = parseInt(vcode.split('-')[0]);
           var v2_idx = parseInt(vcode.split('-')[1]);
-          var row_from_first_table = jq(jq('form#variations table').first().find('tr')[v2_idx + 1]);
+          var row_from_first_table = $($('form#variations table').first().find('tr')[v2_idx + 1]);
 
-          var tables = jq('.varTable');
+          var tables = $('.varTable');
           tables.each(function(tbl_idx, tbl_element) {
-              var rows = jq(this).find('tr');
-              var matching_row = jq(rows[v2_idx + 1]); // + 1 because first one is header row
+              var rows = $(this).find('tr');
+              var matching_row = $(rows[v2_idx + 1]); // + 1 because first one is header row
               var new_row = matching_row.clone();
               matching_row.after(new_row);
               new_row.find('input').each(function() {
-                  jq(this).val('');
+                  $(this).val('');
               });
               new_row.find('.attribute-label').first().text('Neue Variante');
 
@@ -80,17 +80,17 @@ jq(function () {
 
 
       // Delete a variant
-      jq('.del-variant').live('click', function(event) {
-          var clicked_row = jq(this).parents('tr');
+      $('.del-variant').live('click', function(event) {
+          var clicked_row = $(this).parents('tr');
           var vcode = clicked_row.find('input').first().attr('name').replace('-active:boolean', '').replace('var-', '');
           var v1_idx = parseInt(vcode.split('-')[0]);
           var v2_idx = parseInt(vcode.split('-')[1]);
-          var row_from_first_table = jq(jq('form#variations table').first().find('tr')[v2_idx + 1]);
+          var row_from_first_table = $($('form#variations table').first().find('tr')[v2_idx + 1]);
 
-          var tables = jq('.varTable');
+          var tables = $('.varTable');
           tables.each(function(tbl_idx, tbl_element) {
-              var rows = jq(this).find('tr');
-              var matching_row = jq(rows[v2_idx + 1]); // + 1 because first one is header row
+              var rows = $(this).find('tr');
+              var matching_row = $(rows[v2_idx + 1]); // + 1 because first one is header row
               matching_row.remove();
           });
 
@@ -99,31 +99,31 @@ jq(function () {
       });
 
       // Delete an attribute
-      jq('.del-attribute').live('click', function(event) {
-          var attr = jq(this).parent();
+      $('.del-attribute').live('click', function(event) {
+          var attr = $(this).parent();
           attr.slideUp().delay(500).remove();
       });
 
       // Store old variant name if it's about to be renamed
-      jq('input.attributeLabelInput').live('focus', function(event) {
-          jq(this).data('old_value', jq(this).val());
+      $('input.attributeLabelInput').live('focus', function(event) {
+          $(this).data('old_value', $(this).val());
       });
 
       // Rename all occurences of the variant
-      jq('input.attributeLabelInput').live('change', function(event) {
-          var new_variant_name = jq(this).val();
-          var v2_idx = parseInt(jq(this).attr('name').replace('v2-value-', ''));
-          var linked_labels = jq('.varTable tr:nth-child(' + (v2_idx + 1) +') .attribute-label');
+      $('input.attributeLabelInput').live('change', function(event) {
+          var new_variant_name = $(this).val();
+          var v2_idx = parseInt($(this).attr('name').replace('v2-value-', ''));
+          var linked_labels = $('.varTable tr:nth-child(' + (v2_idx + 1) +') .attribute-label');
 
-          jq(linked_labels).each(function () {
-              var el = jq(this);
+          $(linked_labels).each(function () {
+              var el = $(this);
               el.text(new_variant_name);
           });
 
       });
-      
+
     // Make the combinations sortable by the user
-    jq(".sortable").sortable({
+    $(".sortable").sortable({
      revert: true,
      handle: ".drag-variant",
      axis: "y",
@@ -132,19 +132,19 @@ jq(function () {
      update: function(event, ui) {
          update_vcodes();
      }
-     
+
     });
 
     // Disabled all inactive rows on page load
-    jq("form#variations input[type=checkbox]").not(":checked").each(function () {
-              var row = jq(this).parents('tr');
+    $("form#variations input[type=checkbox]").not(":checked").each(function () {
+              var row = $(this).parents('tr');
               row.find('input').not('.varActiveCheckbox').not('.attributeLabelInput').each(function() {
-                  var current_val = jq(this).attr('disabled');
+                  var current_val = $(this).attr('disabled');
                   if (current_val === true) {
-                      jq(this).removeAttr('disabled');
+                      $(this).removeAttr('disabled');
                   }
                   else {
-                      jq(this).attr('disabled', true);
+                      $(this).attr('disabled', true);
                   }
               });
               row.toggleClass('greyed-out');

--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -1,22 +1,22 @@
-jq(function () {
+jQuery(function ($) {
     // Add item to cart through AJAX request
-    jq('input[name="addtocart"]').click(function (event) {
+    $('input[name="addtocart"]').click(function (event) {
         event.preventDefault();
 
-        if (jq(this).hasClass('compact')) {
+        if ($(this).hasClass('compact')) {
             // We're in compact_view, therefore the input's positions inside
             // the forms are different
             // Get the containing form's action URL
             var url;
-            url = jq(this).parents('form').attr('action');
-            var var1choice = jq(this).parents('form').find('select[name="var1choice"]').find('option:selected').val();
-            var var2choice = jq(this).parents('form').find('select[name="var2choice"]').find('option:selected').val();
+            url = $(this).parents('form').attr('action');
+            var var1choice = $(this).parents('form').find('select[name="var1choice"]').find('option:selected').val();
+            var var2choice = $(this).parents('form').find('select[name="var2choice"]').find('option:selected').val();
             var itemdata;
             if (var1choice == undefined) {
                 // We don't have variations - reference the item by its skuCode
                 itemdata = {
-                    skuCode: jq(this).parents('form').find('input[name="skuCode"]').val(),
-                    quantity: jq(this).parents('form').find('input[name="quantity:int"]').val()
+                    skuCode: $(this).parents('form').find('input[name="skuCode"]').val(),
+                    quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
                 };
             }
             else {
@@ -24,7 +24,7 @@ jq(function () {
                     // We've got one variation
                     itemdata = {
                         var1choice: var1choice,
-                        quantity: jq(this).parents('form').find('input[name="quantity:int"]').val()
+                        quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
                     };
                 }
                 else {
@@ -32,18 +32,18 @@ jq(function () {
                     itemdata = {
                         var1choice: var1choice,
                         var2choice: var2choice,
-                        quantity: jq(this).parents('form').find('input[name="quantity:int"]').val()
+                        quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
                     };
                 }
             }
         }
         else {
             // Get the containing form's action URL
-            url = jq(this).parent().attr('action');
+            url = $(this).parent().attr('action');
             // Get skuCode and quantity from adjacent input fields
             itemdata = {
-                skuCode: jq(this).parents('form').find('input[name="skuCode"]').val(),
-                quantity: jq(this).parents('form').find('input[name="quantity:int"]').val()
+                skuCode: $(this).parents('form').find('input[name="skuCode"]').val(),
+                quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
             };
         }
 
@@ -51,121 +51,121 @@ jq(function () {
             // Add item to cart, receive updated portlet html and translated status message
             var portlet_html = response['portlet_html'];
             var status_message = response['status_message'];
-            jq('.portletCartPortlet').replaceWith(portlet_html);
-            jq('#kssPortalMessage').html(status_message);
-            jq('#kssPortalMessage').fadeIn().animate({opacity: 1.0}, 2000).fadeOut();
+            $('.portletCartPortlet').replaceWith(portlet_html);
+            $('#kssPortalMessage').html(status_message);
+            $('#kssPortalMessage').fadeIn().animate({opacity: 1.0}, 2000).fadeOut();
         });
 
         // Reset quantity to 1
-        jq(this).parents('form').find('input[name="quantity:int"]').val('1');
+        $(this).parents('form').find('input[name="quantity:int"]').val('1');
     });
 
 
     // Only show matching item variation depending on user selection
-    jq(".variation-toplevel-group select").change(function () {
-        var uid = jq(this).parents("form").find('input[name="uid"]').val();
+    $(".variation-toplevel-group select").change(function () {
+        var uid = $(this).parents("form").find('input[name="uid"]').val();
 
         var varcode;
-        var v2select = jq(this).parents("form").find('select[name="var2choice"]');
+        var v2select = $(this).parents("form").find('select[name="var2choice"]');
         if (v2select.length == 0) {
             // We only have one variation
-            varcode = "var-" + jq(this).parent().find('select[name="var1choice"] option:selected').attr("value");
+            varcode = "var-" + $(this).parent().find('select[name="var1choice"] option:selected').attr("value");
         }
         else {
             // We've got two variations
-            var var1choice = jq('select[name="var1choice"] option:selected').attr("value");
-            var var2choice = jq('select[name="var2choice"] option:selected').attr("value");
+            var var1choice = $('select[name="var1choice"] option:selected').attr("value");
+            var var2choice = $('select[name="var2choice"] option:selected').attr("value");
             varcode = "var-" + var1choice + "-" + var2choice;
 
             // Grey out variations that are deactivated
-            var other_select = jq(this).parents("form").find("select").not(jq(this));
+            var other_select = $(this).parents("form").find("select").not($(this));
             if (other_select.attr("name") === "var1choice") {
-                var varcode_right_part = jq(this).attr("value");
+                var varcode_right_part = $(this).attr("value");
                 other_select.find('option').each(function () {
-                    var option_val = jq(this).attr("value");
-                    var option_text = jq(this).text();
-                    option_vcode = "var-" + jq(this).attr("value") + "-" + varcode_right_part;
+                    var option_val = $(this).attr("value");
+                    var option_text = $(this).text();
+                    option_vcode = "var-" + $(this).attr("value") + "-" + varcode_right_part;
                     var active = varDicts[uid][option_vcode]['active'];
                     if (active === false) {
                         // add css class "greyed-out"
                         // because IE doesn't detect css class changes in options we remove
                         // the option and add a new one with the desired class.
-                        jq(this).remove();
+                        $(this).remove();
                         other_select.append('<option class="greyed-out" value="' + option_val + '">' + option_text + '</option>');
                     }
                     else {
                         // remove css class "greyed-out"
                         // because IE doesn't detect css class changes in options we remove
                         // the option and add a new one without the class attribute.
-                        jq(this).remove();
+                        $(this).remove();
                         other_select.append('<option value="' + option_val + '">' + option_text + '</option>');
                     }
                 });
                 // restore selection
-                jq('select[name="var1choice"] option[value="'+var1choice+'"]').attr('selected', 'selected');
-                
+                $('select[name="var1choice"] option[value="'+var1choice+'"]').attr('selected', 'selected');
+
             }
             else {
-                var varcode_left_part = jq(this).attr("value");
+                var varcode_left_part = $(this).attr("value");
                 other_select.find('option').each(function () {
-                    var option_val = jq(this).attr("value");
-                    var option_text = jq(this).text();
-                    option_vcode =  "var-" + varcode_left_part + "-" + jq(this).attr("value");
+                    var option_val = $(this).attr("value");
+                    var option_text = $(this).text();
+                    option_vcode =  "var-" + varcode_left_part + "-" + $(this).attr("value");
                     if (varDicts[uid][option_vcode]['active'] === false) {
                         // add css class "greyed-out"
-                        jq(this).remove();
+                        $(this).remove();
                         other_select.append('<option class="greyed-out" value="' + option_val + '">' + option_text + '</option>');
                     }
                     else {
                         // remove css class "greyed-out"
-                        jq(this).remove();
+                        $(this).remove();
                         other_select.append('<option value="' + option_val + '">' + option_text + '</option>');
                     }
                 });
                 // restore selection
-                jq('select[name="var2choice"] option[value="'+var2choice+'"]').attr('selected', 'selected');
+                $('select[name="var2choice"] option[value="'+var2choice+'"]').attr('selected', 'selected');
             }
         }
 
-        jq(this).parents(".variation-toplevel-group").find("table.itemDataTable tr").hide();
+        $(this).parents(".variation-toplevel-group").find("table.itemDataTable tr").hide();
 
         // Place Price and SKU code directly in variation selection table
-        varSelectTable = jq(this).parents(".variation-toplevel-group").find("table.variationSelection");
+        varSelectTable = $(this).parents(".variation-toplevel-group").find("table.variationSelection");
         varPrice = varDicts[uid][varcode]['price'];
         varSkuCode = varDicts[uid][varcode]['skuCode'];
         varDescription = varDicts[uid][varcode]['description'];
 
         varSelectTable.find("td.variationPrice").text("CHF " + varPrice);
         varSelectTable.find("td.variationSKUCode").text(varSkuCode);
-        jq(this).parents(".variation-toplevel-group").find("span.variationDescription").text(varDescription);
-        jq(this).parents(".variation-toplevel-group").find("span.variationDescription").show();
+        $(this).parents(".variation-toplevel-group").find("span.variationDescription").text(varDescription);
+        $(this).parents(".variation-toplevel-group").find("span.variationDescription").show();
 
         varSelectTable.find("td.variationPrice").show();
         varSelectTable.find("td.variationSKUCode").show();
         varSelectTable.find("td.variationPriceLabel").show();
         varSelectTable.find("td.variationSKUCodeLabel").show();
-        jq(this).parents(".variation-toplevel-group").find("table.itemDataTable").hide();
+        $(this).parents(".variation-toplevel-group").find("table.itemDataTable").hide();
 
         // Disable "add to cart" button if variation is disabled
         if (varDicts[uid][varcode]['active']) {
-            jq(this).parents("form").find('input[name="addtocart"]').attr("disabled", false);
-            jq(this).parents("form").find('input[name="quantity:int"]').attr("disabled", false);
+            $(this).parents("form").find('input[name="addtocart"]').attr("disabled", false);
+            $(this).parents("form").find('input[name="quantity:int"]').attr("disabled", false);
 
             // Only un-hide the item data if item is active
-            jq(this).parents(".variation-toplevel-group").find("table.itemDataTable tr").each(function () {
-                if (varcode == jq(this).attr("id")) {
-                    jq(this).show();
+            $(this).parents(".variation-toplevel-group").find("table.itemDataTable tr").each(function () {
+                if (varcode == $(this).attr("id")) {
+                    $(this).show();
                 }
             });
         }
         else {
             // Inactive variation
             // Hide 'add to cart' button, quantity, price, SKU code and description
-            jq(this).parents("form").find('input[name="addtocart"]').attr("disabled", true);
-            jq(this).parents("form").find('input[name="quantity:int"]').attr("disabled", true);
+            $(this).parents("form").find('input[name="addtocart"]').attr("disabled", true);
+            $(this).parents("form").find('input[name="quantity:int"]').attr("disabled", true);
             varSelectTable.find("td.variationPrice").text("");
             varSelectTable.find("td.variationSKUCode").text("");
-            jq(this).parents(".variation-toplevel-group").find("span.variationDescription").text("");
+            $(this).parents(".variation-toplevel-group").find("span.variationDescription").text("");
         }
 
 

--- a/ftw/shop/browser/resources/shop_config.js
+++ b/ftw/shop/browser/resources/shop_config.js
@@ -1,22 +1,16 @@
-jq(function() {
+jQuery(function($) {
 
     // Hide Enabled Payment Processor selection if NoPaymentProcessorStepGroup selected
-    jq("select#form-widgets-payment_processor_step_group").change(function () {
+    $("select#form-widgets-payment_processor_step_group").change(function () {
 
-        if (jq("select#form-widgets-payment_processor_step_group option:selected").attr("value") == "ftw.shop.NoPaymentProcessorStepGroup") {
+        if ($("select#form-widgets-payment_processor_step_group option:selected").attr("value") == "ftw.shop.NoPaymentProcessorStepGroup") {
             // hide
-     	   jq("#formfield-form-widgets-enabled_payment_processors").hide();
+     	   $("#formfield-form-widgets-enabled_payment_processors").hide();
         }
         else {
             // show
-     	   jq("#formfield-form-widgets-enabled_payment_processors").show();
+     	   $("#formfield-form-widgets-enabled_payment_processors").show();
         }
    }).change();
-  
+
 });
-
-     
-
-
-     
-     


### PR DESCRIPTION
Replaces all "jq"s in JavaScript with jQuery's and scoped $'s, since in Plone 4.3 has no jquery integration any more.
/cc @lukasgraf 
