### PR TITLE
Avoid caching of shopping cart AJAX requests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- JS: Use POST method and explicitely disable caching for addtocart_ajax requests.
+  [lgraf]
+
 - Javascript: replace jq with jQuery / $ for Plone 4.3 compatibility.
   [jone]
 

--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -50,6 +50,8 @@ jQuery(function ($) {
         $.ajax({
         dataType: "json",
         url: url + "_ajax",
+        type: "POST",
+        cache: false,
         data: itemdata,
         success: function (response) {
             // Add item to cart, receive updated portlet html and translated status message


### PR DESCRIPTION
When adding items to shopping cart, avoid caching of the responses to the AJAX requests by
- using `POST` instead of `GET` requests
- explicitely setting `cache: false` (causing jQuery to append a timestamp to the request and set respective caching headers)
