### PR TITLE
Fix tests by declaring p.a.testing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
+    'plone.app.testing',
     'pyquery<=0.6.1',
     'zope.testing',
     ]


### PR DESCRIPTION
ftw.testbrowser does no longer depend on plone.app.testing, thus the dependency needs to be declared.
This should fix the currently failing tests.

The dependencies should be updated in general, `bin/dependencychecker` says:

```
Missing requirements
====================
     AccessControl
     Acquisition
     Persistence
     Products.ATContentTypes
     Products.Archetypes
     Products.CMFCore
     Products.GenericSetup
     Products.LinguaPlone.public.BooleanField
     Products.LinguaPlone.public.registerType
     Products.MailHost
     Products.statusmessages
     ZODB3
     Zope2
     archetypes.schemaextender
     plone.app.contentmenu
     plone.app.portlets
     plone.app.upgrade
     plone.i18n
     plone.memoize
     plone.portlets
     plone.registry
     plone.testing
     plone.theme
     plone.z3cform
     transaction
     z3c.form
     zope.annotation
     zope.app.component
     zope.app.container
     zope.app.pagetemplate
     zope.browserpage
     zope.component
     zope.formlib
     zope.i18n
     zope.i18nmessageid
     zope.interface
     zope.lifecycleevent
     zope.publisher
     zope.schema

Missing test requirements
=========================
     Products.Archetypes
     Products.CMFCore
     Products.CMFPlone
     Products.Five.testbrowser.Browser
     Zope2
     checkout
     plone.portlets
     plone.registry
     plone.testing
     transaction
     unittest2
     zope.component
     zope.configuration
     zope.event
     zope.interface
     zope.schema

Unneeded requirements
=====================
     collective.js.jqueryui
     plone.api

Unneeded test requirements
==========================
     zope.testing
```

@lukasgraf can you take a look at this one?
