### PR TITLE
Fix variation-toplevel-group css. FF floats the table around the image.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix variation-toplevel-group css. FF floats the table around the image.
+  [mathias.leimgruber]
 
 
 2.0.1 (2014-08-12)

--- a/ftw/shop/browser/resources/ftw_shop.css
+++ b/ftw/shop/browser/resources/ftw_shop.css
@@ -254,3 +254,7 @@ input#shipping_address-widgets-title, input#contact_information-widgets-title {
     font-size: 100% !important;
     font-weight: normal !important;
 }
+
+.variation-toplevel-group{
+    clear: both;
+}


### PR DESCRIPTION
in FF:

![screen shot 2014-08-13 at 16 25 26](https://cloud.githubusercontent.com/assets/437933/3906776/18844254-22f6-11e4-852d-d4d0bb686803.png)

@lukasgraf 
