### PR TITLE
Fix adapter lookup for external payment processors.

### DIFF
--- a/ftw/shop/browser/cart.py
+++ b/ftw/shop/browser/cart.py
@@ -474,7 +474,7 @@ class CartView(BrowserView):
         # Get the payment processor selected by the customer
         payment_processor_name = session.get(
             'payment_processor_choice').get('payment_processor')
-        for name, adapter in getAdapters((context, None, context),
+        for name, adapter in getAdapters((context, context.REQUEST, context),
                                          IPaymentProcessor):
             if name == payment_processor_name:
                 payment_processor = adapter


### PR DESCRIPTION
This fixes:

```

Time    2014/08/13 15:13:20.537926 GMT+2
User Name (User Id) Anonymous User (None)
Request URL http://test.zug.ch/behoerden/gemeinden/hunenberg/de/checkout
Exception Type  UnboundLocalError
Exception Value local variable 'payment_processor' referenced before assignment
Traceback (innermost last):

Module ZPublisher.Publish, line 70, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module ftw.shop.browser.cart, line 482, in checkout
```

@lukasgraf 

I missed that one in a last commit...

thus also no changelog entry.
