### PR TITLE
Set reply-to to customer for shop-owner and supplier mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set reply-to to customer for shop-owner and supplier mails.
+  [jone]
 
 
 2.0.2 (2014-08-13)

--- a/ftw/shop/browser/ordermanager.py
+++ b/ftw/shop/browser/ordermanager.py
@@ -417,6 +417,7 @@ class OrderManagerView(BrowserView):
         mail_to = formataddr(("Shop Owner", self.shop_config.shop_email))
         customer_name = "%s %s" % (order.customer_firstname,
                                    order.customer_lastname)
+        customer_address = formataddr((customer_name, order.customer_email))
         mail_subject = '[%s] Order %s by %s' % (self.shop_config.shop_name,
                                                order.order_id,
                                                customer_name)
@@ -426,7 +427,7 @@ class OrderManagerView(BrowserView):
         msg_body = mail_view(order=order,
                              show_prices=show_prices,
                              shop_config=self.shop_config)
-        self._send_mail(mail_to, mail_subject, msg_body)
+        self._send_mail(mail_to, mail_subject, msg_body, reply_to=customer_address)
 
     def _send_customer_mail(self, order, lang):
         """Send order confirmation mail to customer
@@ -456,6 +457,7 @@ class OrderManagerView(BrowserView):
         mail_to = formataddr(supplier)
         customer_name = "%s %s" % (order.customer_firstname,
                                    order.customer_lastname)
+        customer_address = formataddr((customer_name, order.customer_email))
         mail_subject = '[%s] Order %s by %s' % (self.shop_config.shop_name,
                                                order.order_id,
                                                customer_name)
@@ -466,9 +468,9 @@ class OrderManagerView(BrowserView):
                              show_prices=show_prices,
                              shop_config=self.shop_config,
                              supplier=supplier)
-        self._send_mail(mail_to, mail_subject, msg_body)
+        self._send_mail(mail_to, mail_subject, msg_body, reply_to=customer_address)
 
-    def _send_mail(self, to, subject, body):
+    def _send_mail(self, to, subject, body, reply_to=None):
         """Send mail originating from the shop.
         """
 
@@ -479,6 +481,7 @@ class OrderManagerView(BrowserView):
              mto=to,
              mfrom=mail_from,
              mbcc=mail_bcc,
+             reply_to=reply_to,
              subject=subject,
              encode=None,
              immediate=False,

--- a/ftw/shop/mailer.py
+++ b/ftw/shop/mailer.py
@@ -29,7 +29,7 @@ class MailHostAdapter(object):
     def __init__(self, context):
         self.context = context
 
-    def send(self, msg_body, mto, mfrom=None, mbcc=None, subject=None,
+    def send(self, msg_body, mto, mfrom=None, mbcc=None, reply_to=None, subject=None,
              encode=None, immediate=False, charset=None, msg_type=None):
         """Sends a message defined at least by its message body and the
         destination address.
@@ -45,6 +45,9 @@ class MailHostAdapter(object):
                 encode_base64(msg)
 
             msg['BCC']= Header(mbcc)
+            if reply_to:
+                msg['Reply-To'] = Header(reply_to)
+
             mhost.send(msg,
                          mto=mto,
                          mfrom=mfrom,

--- a/ftw/shop/tests/test_checkout_shopowner_mail.py
+++ b/ftw/shop/tests/test_checkout_shopowner_mail.py
@@ -69,6 +69,12 @@ class TestCheckoutMailToShopOwner(TestCase):
                                  r'^\[Webshop\] Order \d* by Hugo Boss$')
 
     @browsing
+    def test_shop_owner_replies_to_customer(self, browser):
+        mail = self.checkout_and_get_mail()
+        self.assertEquals(['Hugo Boss <hugo@boss.com>'],
+                          get_mail_header(mail, 'Reply-To'))
+
+    @browsing
     def test_personal_information(self, browser):
         self.open_mail_in_browser(self.checkout_and_get_mail(), browser)
 


### PR DESCRIPTION
The sender of all mails is always the shop owner, because of the SPF.
When the shop owner (or the supplier) response to the order email and does not change the recipient, the mail will be sent to the shop owner.

In order to make it easier to respond to the customer I've added a `Reply-To`-Header to customer and supplier emails, set to the customer email.

I've only updated the Plone 4 part of the `MailHostAdapter`, since we no longer officially support older Plone versions and it works differently for Plone 3.
