### PR TITLE
Validate email address in checkout form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Validate email address in checkout form.
+  [jone]
 
 
 2.0.3 (2014-08-29)

--- a/ftw/shop/configure.zcml
+++ b/ftw/shop/configure.zcml
@@ -87,6 +87,8 @@
       component=".vocabularies.ContactInfoStepGroups"
       />
 
+    <adapter factory=".interfaces.EmailAddressValidator" />
+
     <!-- Shipping Address StepGroups Vocabulary -->
     <utility
     provides="zope.schema.interfaces.IVocabularyFactory"

--- a/ftw/shop/interfaces.py
+++ b/ftw/shop/interfaces.py
@@ -1,9 +1,13 @@
 from ftw.shop import shopMessageFactory as _
 from ftw.shop.config import DEFAULT_VAT_RATES
+from ftw.shop.utils import is_email_valid
 from plone.theme.interfaces import IDefaultPloneLayer
+from z3c.form import validator
 from z3c.form.interfaces import IRadioWidget
+from z3c.form.validator import SimpleFieldValidator
 from zope import schema
 from zope.interface import Interface
+from zope.interface import Invalid
 
 
 class IShopRoot(Interface):
@@ -328,6 +332,19 @@ class IDefaultContactInformation(Interface):
     comments = schema.Text(
             title=_(u'label_comments', default=u'Comments'),
             required=False)
+
+
+class EmailAddressValidator(SimpleFieldValidator):
+
+    def validate(self, value):
+        super(EmailAddressValidator, self).validate(value)
+        if not value or not is_email_valid(value):
+            raise Invalid(_(u'This email address is invalid.'))
+
+
+validator.WidgetValidatorDiscriminators(
+    EmailAddressValidator,
+    field=IDefaultContactInformation['email'])
 
 
 class IShippingAddress(Interface):

--- a/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-28 08:45+0000\n"
+"POT-Creation-Date: 2014-09-02 14:03+0000\n"
 "PO-Revision-Date: 2013-12-28 14:42+0100\n"
 "Last-Translator: Lukas Graf <lukas.graf@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -82,6 +82,10 @@ msgstr "Shop-Artikel"
 #: ./ftw/shop/profiles/default/types/Supplier.xml
 msgid "Supplier"
 msgstr "Lieferant"
+
+#: ./ftw/shop/interfaces.py:342
+msgid "This email address is invalid."
+msgstr "Diese E-Mail Adresse ist ungültig."
 
 #: ./ftw/shop/portlets/cart.py:112
 msgid "This portlet displays the Shopping Cart."
@@ -253,7 +257,7 @@ msgid "help_add_cart_portlet"
 msgstr "Dieses Portlet zeigt den Inhalt des Warenkorbs an"
 
 #. Default: "Also send eMail to owner if supplier(s) have been notified"
-#: ./ftw/shop/interfaces.py:191
+#: ./ftw/shop/interfaces.py:195
 msgid "help_always_notify_shop_owner"
 msgstr "Auch dann eine eMail an den Shopbesitzer senden wenn Lieferant(en) benachrichtigt wurde(n)"
 
@@ -270,7 +274,7 @@ msgid "help_default_shipping_address_step"
 msgstr ""
 
 #. Default: "The subject for order mails."
-#: ./ftw/shop/interfaces.py:174
+#: ./ftw/shop/interfaces.py:178
 msgid "help_mail_subject"
 msgstr ""
 
@@ -284,11 +288,11 @@ msgid "help_order_review_step"
 msgstr ""
 
 #. Default: "Will be displayed in the customer confirmation mail as contact information when configured."
-#: ./ftw/shop/interfaces.py:182
+#: ./ftw/shop/interfaces.py:186
 msgid "help_phone_number"
 msgstr "Wird im Bestätigungsmail an den Kunden dargestellt."
 
-#: ./ftw/shop/interfaces.py:250
+#: ./ftw/shop/interfaces.py:254
 msgid "help_show_status_column"
 msgstr ""
 
@@ -297,15 +301,15 @@ msgstr ""
 msgid "help_supplier_address"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:258
+#: ./ftw/shop/interfaces.py:262
 msgid "help_vat_enabled"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:266
+#: ./ftw/shop/interfaces.py:270
 msgid "help_vat_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:274
+#: ./ftw/shop/interfaces.py:278
 msgid "help_vat_rates"
 msgstr ""
 
@@ -325,7 +329,7 @@ msgid "label_always"
 msgstr "Immer"
 
 #. Default: "Always notify shop owner about orders"
-#: ./ftw/shop/interfaces.py:189
+#: ./ftw/shop/interfaces.py:193
 msgid "label_always_notify_shop_owner"
 msgstr "Shop-Besitzer immer über Bestellungen benachrichtigen"
 
@@ -377,18 +381,18 @@ msgid "label_checkout_wizard"
 msgstr "Bestellvorgang"
 
 #. Default: "City"
-#: ./ftw/shop/interfaces.py:321
+#: ./ftw/shop/interfaces.py:325
 msgid "label_city"
 msgstr "Ort"
 
 #. Default: "Comments"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:329
+#: ./ftw/shop/interfaces.py:333
 msgid "label_comments"
 msgstr "Bemerkungen"
 
 #. Default: "Company"
-#: ./ftw/shop/interfaces.py:301
+#: ./ftw/shop/interfaces.py:305
 msgid "label_company"
 msgstr "Firma"
 
@@ -398,12 +402,12 @@ msgid "label_config_variations"
 msgstr "Variationen konfigurieren"
 
 #. Default: "Contact Information Step Group"
-#: ./ftw/shop/interfaces.py:220
+#: ./ftw/shop/interfaces.py:224
 msgid "label_contact_info_step_group"
 msgstr "Kontaktinformations-Schritt"
 
 #. Default: "Country"
-#: ./ftw/shop/interfaces.py:325
+#: ./ftw/shop/interfaces.py:329
 msgid "label_country"
 msgstr "Land"
 
@@ -480,12 +484,12 @@ msgid "label_email"
 msgstr "E-Mail"
 
 #. Default: "Enabled Payment Processors"
-#: ./ftw/shop/interfaces.py:204
+#: ./ftw/shop/interfaces.py:208
 msgid "label_enabled_payment_processors"
 msgstr "Aktivierte Zahlungsanbieter"
 
 #. Default: "First Name"
-#: ./ftw/shop/interfaces.py:289
+#: ./ftw/shop/interfaces.py:293
 msgid "label_firstname"
 msgstr "Vorname"
 
@@ -507,12 +511,12 @@ msgid "label_included_vat"
 msgstr "MwSt"
 
 #. Default: "Last Name"
-#: ./ftw/shop/interfaces.py:293
+#: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "BCC Address"
-#: ./ftw/shop/interfaces.py:167
+#: ./ftw/shop/interfaces.py:171
 msgid "label_mail_bcc"
 msgstr "BCC Adresse"
 
@@ -522,7 +526,7 @@ msgid "label_mail_group"
 msgstr "e-Mail"
 
 #. Default: "Subject"
-#: ./ftw/shop/interfaces.py:172
+#: ./ftw/shop/interfaces.py:176
 msgid "label_mail_subject"
 msgstr "Betreff"
 
@@ -557,7 +561,7 @@ msgid "label_order_review_step"
 msgstr "Bestellungsübersicht"
 
 #. Default: "Order Review Step Group"
-#: ./ftw/shop/interfaces.py:234
+#: ./ftw/shop/interfaces.py:238
 msgid "label_order_review_step_group"
 msgstr "Bestellungsübersichts-Schritt"
 
@@ -568,18 +572,18 @@ msgid "label_order_status"
 msgstr "Bestellungs-Status"
 
 #. Default: "Order Storage method"
-#: ./ftw/shop/interfaces.py:213
+#: ./ftw/shop/interfaces.py:217
 msgid "label_order_storage"
 msgstr "Storage-Methode für Bestellungen"
 
 #. Default: "Payment Processor"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:90
-#: ./ftw/shop/interfaces.py:124
+#: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Zahlungsanbieter"
 
 #. Default: "Payment Processor Step Group"
-#: ./ftw/shop/interfaces.py:197
+#: ./ftw/shop/interfaces.py:201
 msgid "label_payment_processor_step_group"
 msgstr "Zahlungsanbieter-Schritt"
 
@@ -596,7 +600,7 @@ msgid "label_phone"
 msgstr "Tel."
 
 #. Default: "Phone number"
-#: ./ftw/shop/interfaces.py:180
+#: ./ftw/shop/interfaces.py:184
 msgid "label_phone_number"
 msgstr "Telefonnummer"
 
@@ -618,7 +622,7 @@ msgid "label_shipping_address"
 msgstr "Lieferadresse"
 
 #. Default: "Shipping Address Step Group"
-#: ./ftw/shop/interfaces.py:227
+#: ./ftw/shop/interfaces.py:231
 msgid "label_shipping_address_step_group"
 msgstr "Lieferadresse-Schritt"
 
@@ -628,12 +632,12 @@ msgid "label_shop_configuration"
 msgstr "Shop-Einrichtung"
 
 #. Default: "Sender e-Mail Address"
-#: ./ftw/shop/interfaces.py:162
+#: ./ftw/shop/interfaces.py:166
 msgid "label_shop_email"
 msgstr "Absender e-Mail-Adresse"
 
 #. Default: "Enter the shop name"
-#: ./ftw/shop/interfaces.py:157
+#: ./ftw/shop/interfaces.py:161
 msgid "label_shop_name"
 msgstr "Geben sie den Shop-Namen ein"
 
@@ -644,7 +648,7 @@ msgid "label_show_price"
 msgstr "Preis anzeigen"
 
 #. Default: "Show status column in order manager"
-#: ./ftw/shop/interfaces.py:248
+#: ./ftw/shop/interfaces.py:252
 msgid "label_show_status_column"
 msgstr "Spalte 'Status' in Bestellungsverwaltung anzeigen"
 
@@ -666,17 +670,17 @@ msgid "label_status"
 msgstr "Status"
 
 #. Default: "Status Set"
-#: ./ftw/shop/interfaces.py:241
+#: ./ftw/shop/interfaces.py:245
 msgid "label_status_set"
 msgstr "Status-Set"
 
 #. Default: "Street/No."
-#: ./ftw/shop/interfaces.py:305
+#: ./ftw/shop/interfaces.py:309
 msgid "label_street"
 msgstr "Strasse/Nr."
 
 #. Default: "Address 2"
-#: ./ftw/shop/interfaces.py:309
+#: ./ftw/shop/interfaces.py:313
 msgid "label_street2"
 msgstr "Adresszusatz"
 
@@ -708,7 +712,7 @@ msgid "label_supplier_from_parent"
 msgstr "Lieferant aus übergeordneter Kategorie"
 
 #. Default: "Title"
-#: ./ftw/shop/interfaces.py:285
+#: ./ftw/shop/interfaces.py:289
 msgid "label_title"
 msgstr "Anrede"
 
@@ -723,7 +727,7 @@ msgid "label_up_to_shop_setup"
 msgstr "Aufwärts zu Shop-Einrichtung"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:338
+#: ./ftw/shop/interfaces.py:355
 msgid "label_used"
 msgstr "Abweichende Lieferadresse"
 
@@ -757,7 +761,7 @@ msgid "label_vat"
 msgstr "MwSt"
 
 #. Default: "Enable VAT support"
-#: ./ftw/shop/interfaces.py:256
+#: ./ftw/shop/interfaces.py:260
 msgid "label_vat_enabled"
 msgstr "MwSt-Unterstützung aktivieren"
 
@@ -767,7 +771,7 @@ msgid "label_vat_group"
 msgstr "MwSt"
 
 #. Default: "VAT number"
-#: ./ftw/shop/interfaces.py:264
+#: ./ftw/shop/interfaces.py:268
 msgid "label_vat_number"
 msgstr "Mehrwertsteuernummer"
 
@@ -777,12 +781,12 @@ msgid "label_vat_rate"
 msgstr "MwSt-Satz"
 
 #. Default: "VAT rates"
-#: ./ftw/shop/interfaces.py:272
+#: ./ftw/shop/interfaces.py:276
 msgid "label_vat_rates"
 msgstr "MwSt-Sätze"
 
 #. Default: "Zip Code"
-#: ./ftw/shop/interfaces.py:317
+#: ./ftw/shop/interfaces.py:321
 msgid "label_zipcode"
 msgstr "Postleitzahl"
 
@@ -1029,5 +1033,3 @@ msgstr "Total (inkl. MwSt)"
 #: ./ftw/shop/browser/templates/order_view.pt:121
 msgid "txt_vat"
 msgstr "(inkl. MwSt)"
-
-

--- a/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-28 08:47+0000\n"
+"POT-Creation-Date: 2014-09-02 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Enny Rodriguez <administrador@femto.com.ve>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -85,6 +85,10 @@ msgstr "Artículo"
 #: ./ftw/shop/profiles/default/types/Supplier.xml
 msgid "Supplier"
 msgstr "Proveedor"
+
+#: ./ftw/shop/interfaces.py:342
+msgid "This email address is invalid."
+msgstr ""
 
 #: ./ftw/shop/portlets/cart.py:112
 msgid "This portlet displays the Shopping Cart."
@@ -256,7 +260,7 @@ msgid "help_add_cart_portlet"
 msgstr "Este porlet visualiza el contenido del carrito de compra"
 
 #. Default: "Also send eMail to owner if supplier(s) have been notified"
-#: ./ftw/shop/interfaces.py:191
+#: ./ftw/shop/interfaces.py:195
 msgid "help_always_notify_shop_owner"
 msgstr "También Enviar email al propietario si el proveedor(es) se han notificado"
 
@@ -273,7 +277,7 @@ msgid "help_default_shipping_address_step"
 msgstr "Información de envío"
 
 #. Default: "The subject for order mails."
-#: ./ftw/shop/interfaces.py:174
+#: ./ftw/shop/interfaces.py:178
 msgid "help_mail_subject"
 msgstr "Sujeto para el envío del correo con la información de la orden de compra."
 
@@ -287,11 +291,11 @@ msgid "help_order_review_step"
 msgstr "Revision de la orden"
 
 #. Default: "Will be displayed in the customer confirmation mail as contact information when configured."
-#: ./ftw/shop/interfaces.py:182
+#: ./ftw/shop/interfaces.py:186
 msgid "help_phone_number"
 msgstr "Número teléfonico"
 
-#: ./ftw/shop/interfaces.py:250
+#: ./ftw/shop/interfaces.py:254
 msgid "help_show_status_column"
 msgstr "Estado"
 
@@ -300,15 +304,15 @@ msgstr "Estado"
 msgid "help_supplier_address"
 msgstr "Dirección del proveedor"
 
-#: ./ftw/shop/interfaces.py:258
+#: ./ftw/shop/interfaces.py:262
 msgid "help_vat_enabled"
 msgstr "I.V.A Habilitado"
 
-#: ./ftw/shop/interfaces.py:266
+#: ./ftw/shop/interfaces.py:270
 msgid "help_vat_number"
 msgstr "I.V.A"
 
-#: ./ftw/shop/interfaces.py:274
+#: ./ftw/shop/interfaces.py:278
 msgid "help_vat_rates"
 msgstr "I.V.A valor"
 
@@ -328,7 +332,7 @@ msgid "label_always"
 msgstr "Siempre"
 
 #. Default: "Always notify shop owner about orders"
-#: ./ftw/shop/interfaces.py:189
+#: ./ftw/shop/interfaces.py:193
 msgid "label_always_notify_shop_owner"
 msgstr "Notificar siempre al propietario de la tienda acerca de las ordenes"
 
@@ -380,18 +384,18 @@ msgid "label_checkout_wizard"
 msgstr "Pedido"
 
 #. Default: "City"
-#: ./ftw/shop/interfaces.py:321
+#: ./ftw/shop/interfaces.py:325
 msgid "label_city"
 msgstr "Ciudad"
 
 #. Default: "Comments"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:329
+#: ./ftw/shop/interfaces.py:333
 msgid "label_comments"
 msgstr "Comentarios"
 
 #. Default: "Company"
-#: ./ftw/shop/interfaces.py:301
+#: ./ftw/shop/interfaces.py:305
 msgid "label_company"
 msgstr "Compañia"
 
@@ -401,12 +405,12 @@ msgid "label_config_variations"
 msgstr "Configuracion de las variaciones"
 
 #. Default: "Contact Information Step Group"
-#: ./ftw/shop/interfaces.py:220
+#: ./ftw/shop/interfaces.py:224
 msgid "label_contact_info_step_group"
 msgstr "Paso Información de contacto"
 
 #. Default: "Country"
-#: ./ftw/shop/interfaces.py:325
+#: ./ftw/shop/interfaces.py:329
 msgid "label_country"
 msgstr "País"
 
@@ -483,12 +487,12 @@ msgid "label_email"
 msgstr "Correo electrónico"
 
 #. Default: "Enabled Payment Processors"
-#: ./ftw/shop/interfaces.py:204
+#: ./ftw/shop/interfaces.py:208
 msgid "label_enabled_payment_processors"
 msgstr "Pasarelas de pago hablitadas"
 
 #. Default: "First Name"
-#: ./ftw/shop/interfaces.py:289
+#: ./ftw/shop/interfaces.py:293
 msgid "label_firstname"
 msgstr "Primer nombre"
 
@@ -510,12 +514,12 @@ msgid "label_included_vat"
 msgstr "I.V.A"
 
 #. Default: "Last Name"
-#: ./ftw/shop/interfaces.py:293
+#: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Apellido"
 
 #. Default: "BCC Address"
-#: ./ftw/shop/interfaces.py:167
+#: ./ftw/shop/interfaces.py:171
 msgid "label_mail_bcc"
 msgstr "Direccion BCC"
 
@@ -525,7 +529,7 @@ msgid "label_mail_group"
 msgstr "Correo"
 
 #. Default: "Subject"
-#: ./ftw/shop/interfaces.py:172
+#: ./ftw/shop/interfaces.py:176
 msgid "label_mail_subject"
 msgstr "Sujeto"
 
@@ -560,7 +564,7 @@ msgid "label_order_review_step"
 msgstr "Revision de orden"
 
 #. Default: "Order Review Step Group"
-#: ./ftw/shop/interfaces.py:234
+#: ./ftw/shop/interfaces.py:238
 msgid "label_order_review_step_group"
 msgstr "Paso Revision de la orden"
 
@@ -571,18 +575,18 @@ msgid "label_order_status"
 msgstr "Estado de la orden"
 
 #. Default: "Order Storage method"
-#: ./ftw/shop/interfaces.py:213
+#: ./ftw/shop/interfaces.py:217
 msgid "label_order_storage"
 msgstr "Método de almacenamiento de la orden"
 
 #. Default: "Payment Processor"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:90
-#: ./ftw/shop/interfaces.py:124
+#: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Método de pago"
 
 #. Default: "Payment Processor Step Group"
-#: ./ftw/shop/interfaces.py:197
+#: ./ftw/shop/interfaces.py:201
 msgid "label_payment_processor_step_group"
 msgstr "Paso Método de pago"
 
@@ -599,7 +603,7 @@ msgid "label_phone"
 msgstr "Teléfono"
 
 #. Default: "Phone number"
-#: ./ftw/shop/interfaces.py:180
+#: ./ftw/shop/interfaces.py:184
 msgid "label_phone_number"
 msgstr "Número de teléfono"
 
@@ -621,7 +625,7 @@ msgid "label_shipping_address"
 msgstr "Dirección de envío"
 
 #. Default: "Shipping Address Step Group"
-#: ./ftw/shop/interfaces.py:227
+#: ./ftw/shop/interfaces.py:231
 msgid "label_shipping_address_step_group"
 msgstr "Paso Dirección de envío"
 
@@ -631,12 +635,12 @@ msgid "label_shop_configuration"
 msgstr "Configuración de la tienda"
 
 #. Default: "Sender e-Mail Address"
-#: ./ftw/shop/interfaces.py:162
+#: ./ftw/shop/interfaces.py:166
 msgid "label_shop_email"
 msgstr "Correo electrónico del remitente"
 
 #. Default: "Enter the shop name"
-#: ./ftw/shop/interfaces.py:157
+#: ./ftw/shop/interfaces.py:161
 msgid "label_shop_name"
 msgstr "Ingrese el nombre de la tienda"
 
@@ -647,7 +651,7 @@ msgid "label_show_price"
 msgstr "Mostrar precio"
 
 #. Default: "Show status column in order manager"
-#: ./ftw/shop/interfaces.py:248
+#: ./ftw/shop/interfaces.py:252
 msgid "label_show_status_column"
 msgstr "Mostrar columna de estado en el gestor de ordenes"
 
@@ -669,17 +673,17 @@ msgid "label_status"
 msgstr "Estado"
 
 #. Default: "Status Set"
-#: ./ftw/shop/interfaces.py:241
+#: ./ftw/shop/interfaces.py:245
 msgid "label_status_set"
 msgstr "Definir estado"
 
 #. Default: "Street/No."
-#: ./ftw/shop/interfaces.py:305
+#: ./ftw/shop/interfaces.py:309
 msgid "label_street"
 msgstr "Calle"
 
 #. Default: "Address 2"
-#: ./ftw/shop/interfaces.py:309
+#: ./ftw/shop/interfaces.py:313
 msgid "label_street2"
 msgstr "Dirección 2"
 
@@ -711,7 +715,7 @@ msgid "label_supplier_from_parent"
 msgstr "Proveedor de la categoría padre"
 
 #. Default: "Title"
-#: ./ftw/shop/interfaces.py:285
+#: ./ftw/shop/interfaces.py:289
 msgid "label_title"
 msgstr "Título"
 
@@ -726,7 +730,7 @@ msgid "label_up_to_shop_setup"
 msgstr "Volver a configuración de la tienda"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:338
+#: ./ftw/shop/interfaces.py:355
 msgid "label_used"
 msgstr "Diferente a la dirección de la factura"
 
@@ -760,7 +764,7 @@ msgid "label_vat"
 msgstr "I.V.A"
 
 #. Default: "Enable VAT support"
-#: ./ftw/shop/interfaces.py:256
+#: ./ftw/shop/interfaces.py:260
 msgid "label_vat_enabled"
 msgstr "Habilitar I.V.A"
 
@@ -770,7 +774,7 @@ msgid "label_vat_group"
 msgstr "I.V.A"
 
 #. Default: "VAT number"
-#: ./ftw/shop/interfaces.py:264
+#: ./ftw/shop/interfaces.py:268
 msgid "label_vat_number"
 msgstr "% de impuesto"
 
@@ -780,12 +784,12 @@ msgid "label_vat_rate"
 msgstr "I.V.A Tasa"
 
 #. Default: "VAT rates"
-#: ./ftw/shop/interfaces.py:272
+#: ./ftw/shop/interfaces.py:276
 msgid "label_vat_rates"
 msgstr "I.V.A Tasas"
 
 #. Default: "Zip Code"
-#: ./ftw/shop/interfaces.py:317
+#: ./ftw/shop/interfaces.py:321
 msgid "label_zipcode"
 msgstr "Código postal"
 

--- a/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-28 08:45+0000\n"
+"POT-Creation-Date: 2014-09-02 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -85,6 +85,10 @@ msgstr "Article boutique"
 
 #: ./ftw/shop/profiles/default/types/Supplier.xml
 msgid "Supplier"
+msgstr ""
+
+#: ./ftw/shop/interfaces.py:342
+msgid "This email address is invalid."
 msgstr ""
 
 #: ./ftw/shop/portlets/cart.py:112
@@ -257,7 +261,7 @@ msgid "help_add_cart_portlet"
 msgstr ""
 
 #. Default: "Also send eMail to owner if supplier(s) have been notified"
-#: ./ftw/shop/interfaces.py:191
+#: ./ftw/shop/interfaces.py:195
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
@@ -274,7 +278,7 @@ msgid "help_default_shipping_address_step"
 msgstr ""
 
 #. Default: "The subject for order mails."
-#: ./ftw/shop/interfaces.py:174
+#: ./ftw/shop/interfaces.py:178
 msgid "help_mail_subject"
 msgstr ""
 
@@ -288,11 +292,11 @@ msgid "help_order_review_step"
 msgstr ""
 
 #. Default: "Will be displayed in the customer confirmation mail as contact information when configured."
-#: ./ftw/shop/interfaces.py:182
+#: ./ftw/shop/interfaces.py:186
 msgid "help_phone_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:250
+#: ./ftw/shop/interfaces.py:254
 msgid "help_show_status_column"
 msgstr ""
 
@@ -301,15 +305,15 @@ msgstr ""
 msgid "help_supplier_address"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:258
+#: ./ftw/shop/interfaces.py:262
 msgid "help_vat_enabled"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:266
+#: ./ftw/shop/interfaces.py:270
 msgid "help_vat_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:274
+#: ./ftw/shop/interfaces.py:278
 msgid "help_vat_rates"
 msgstr ""
 
@@ -329,7 +333,7 @@ msgid "label_always"
 msgstr ""
 
 #. Default: "Always notify shop owner about orders"
-#: ./ftw/shop/interfaces.py:189
+#: ./ftw/shop/interfaces.py:193
 msgid "label_always_notify_shop_owner"
 msgstr "notifier toujour le proprietaire boutique d'une commande'"
 
@@ -381,18 +385,18 @@ msgid "label_checkout_wizard"
 msgstr "Procédure de commande"
 
 #. Default: "City"
-#: ./ftw/shop/interfaces.py:321
+#: ./ftw/shop/interfaces.py:325
 msgid "label_city"
 msgstr "Lieu"
 
 #. Default: "Comments"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:329
+#: ./ftw/shop/interfaces.py:333
 msgid "label_comments"
 msgstr "Remarques"
 
 #. Default: "Company"
-#: ./ftw/shop/interfaces.py:301
+#: ./ftw/shop/interfaces.py:305
 msgid "label_company"
 msgstr "Entreprise"
 
@@ -402,12 +406,12 @@ msgid "label_config_variations"
 msgstr "Configure les variations"
 
 #. Default: "Contact Information Step Group"
-#: ./ftw/shop/interfaces.py:220
+#: ./ftw/shop/interfaces.py:224
 msgid "label_contact_info_step_group"
 msgstr "Étape l'information de contac"
 
 #. Default: "Country"
-#: ./ftw/shop/interfaces.py:325
+#: ./ftw/shop/interfaces.py:329
 msgid "label_country"
 msgstr "Pays"
 
@@ -485,12 +489,12 @@ msgid "label_email"
 msgstr "E-mail"
 
 #. Default: "Enabled Payment Processors"
-#: ./ftw/shop/interfaces.py:204
+#: ./ftw/shop/interfaces.py:208
 msgid "label_enabled_payment_processors"
 msgstr "Fournisseur de paiement activée"
 
 #. Default: "First Name"
-#: ./ftw/shop/interfaces.py:289
+#: ./ftw/shop/interfaces.py:293
 msgid "label_firstname"
 msgstr "Prénom"
 
@@ -512,12 +516,12 @@ msgid "label_included_vat"
 msgstr ""
 
 #. Default: "Last Name"
-#: ./ftw/shop/interfaces.py:293
+#: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "BCC Address"
-#: ./ftw/shop/interfaces.py:167
+#: ./ftw/shop/interfaces.py:171
 msgid "label_mail_bcc"
 msgstr "BBC adresse"
 
@@ -527,7 +531,7 @@ msgid "label_mail_group"
 msgstr ""
 
 #. Default: "Subject"
-#: ./ftw/shop/interfaces.py:172
+#: ./ftw/shop/interfaces.py:176
 msgid "label_mail_subject"
 msgstr ""
 
@@ -562,7 +566,7 @@ msgid "label_order_review_step"
 msgstr "Aperçu de commandes"
 
 #. Default: "Order Review Step Group"
-#: ./ftw/shop/interfaces.py:234
+#: ./ftw/shop/interfaces.py:238
 msgid "label_order_review_step_group"
 msgstr "Étape aperçu de commandes"
 
@@ -573,18 +577,18 @@ msgid "label_order_status"
 msgstr "État de la commande"
 
 #. Default: "Order Storage method"
-#: ./ftw/shop/interfaces.py:213
+#: ./ftw/shop/interfaces.py:217
 msgid "label_order_storage"
 msgstr "Méthode d'enregistrer pour les commandes"
 
 #. Default: "Payment Processor"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:90
-#: ./ftw/shop/interfaces.py:124
+#: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Fournisseur de paiement"
 
 #. Default: "Payment Processor Step Group"
-#: ./ftw/shop/interfaces.py:197
+#: ./ftw/shop/interfaces.py:201
 msgid "label_payment_processor_step_group"
 msgstr "Étape fournisseur de paiement"
 
@@ -601,7 +605,7 @@ msgid "label_phone"
 msgstr "Tél."
 
 #. Default: "Phone number"
-#: ./ftw/shop/interfaces.py:180
+#: ./ftw/shop/interfaces.py:184
 msgid "label_phone_number"
 msgstr "Mobile"
 
@@ -623,7 +627,7 @@ msgid "label_shipping_address"
 msgstr "Adresse de livraison"
 
 #. Default: "Shipping Address Step Group"
-#: ./ftw/shop/interfaces.py:227
+#: ./ftw/shop/interfaces.py:231
 msgid "label_shipping_address_step_group"
 msgstr "Étape adresse de livraison"
 
@@ -633,12 +637,12 @@ msgid "label_shop_configuration"
 msgstr "Configuration de la boutique"
 
 #. Default: "Sender e-Mail Address"
-#: ./ftw/shop/interfaces.py:162
+#: ./ftw/shop/interfaces.py:166
 msgid "label_shop_email"
 msgstr "Expéditeur d'e-mail"
 
 #. Default: "Enter the shop name"
-#: ./ftw/shop/interfaces.py:157
+#: ./ftw/shop/interfaces.py:161
 msgid "label_shop_name"
 msgstr "Entree le nom boutique"
 
@@ -649,7 +653,7 @@ msgid "label_show_price"
 msgstr ""
 
 #. Default: "Show status column in order manager"
-#: ./ftw/shop/interfaces.py:248
+#: ./ftw/shop/interfaces.py:252
 msgid "label_show_status_column"
 msgstr ""
 
@@ -672,17 +676,17 @@ msgid "label_status"
 msgstr ""
 
 #. Default: "Status Set"
-#: ./ftw/shop/interfaces.py:241
+#: ./ftw/shop/interfaces.py:245
 msgid "label_status_set"
 msgstr ""
 
 #. Default: "Street/No."
-#: ./ftw/shop/interfaces.py:305
+#: ./ftw/shop/interfaces.py:309
 msgid "label_street"
 msgstr "Rue / No"
 
 #. Default: "Address 2"
-#: ./ftw/shop/interfaces.py:309
+#: ./ftw/shop/interfaces.py:313
 msgid "label_street2"
 msgstr "Complément d'adresse"
 
@@ -714,7 +718,7 @@ msgid "label_supplier_from_parent"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/shop/interfaces.py:285
+#: ./ftw/shop/interfaces.py:289
 msgid "label_title"
 msgstr "Titre"
 
@@ -729,7 +733,7 @@ msgid "label_up_to_shop_setup"
 msgstr "Jusqu'à l'installation boutique"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:338
+#: ./ftw/shop/interfaces.py:355
 msgid "label_used"
 msgstr "Adresse differe livraison"
 
@@ -763,7 +767,7 @@ msgid "label_vat"
 msgstr ""
 
 #. Default: "Enable VAT support"
-#: ./ftw/shop/interfaces.py:256
+#: ./ftw/shop/interfaces.py:260
 msgid "label_vat_enabled"
 msgstr ""
 
@@ -773,7 +777,7 @@ msgid "label_vat_group"
 msgstr ""
 
 #. Default: "VAT number"
-#: ./ftw/shop/interfaces.py:264
+#: ./ftw/shop/interfaces.py:268
 msgid "label_vat_number"
 msgstr ""
 
@@ -783,12 +787,12 @@ msgid "label_vat_rate"
 msgstr ""
 
 #. Default: "VAT rates"
-#: ./ftw/shop/interfaces.py:272
+#: ./ftw/shop/interfaces.py:276
 msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Zip Code"
-#: ./ftw/shop/interfaces.py:317
+#: ./ftw/shop/interfaces.py:321
 msgid "label_zipcode"
 msgstr "Code postale"
 

--- a/ftw/shop/locales/ftw.shop.pot
+++ b/ftw/shop/locales/ftw.shop.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-28 08:45+0000\n"
+"POT-Creation-Date: 2014-09-02 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -81,6 +81,10 @@ msgstr ""
 
 #: ./ftw/shop/profiles/default/types/Supplier.xml
 msgid "Supplier"
+msgstr ""
+
+#: ./ftw/shop/interfaces.py:342
+msgid "This email address is invalid."
 msgstr ""
 
 #: ./ftw/shop/portlets/cart.py:112
@@ -253,7 +257,7 @@ msgid "help_add_cart_portlet"
 msgstr ""
 
 #. Default: "Also send eMail to owner if supplier(s) have been notified"
-#: ./ftw/shop/interfaces.py:191
+#: ./ftw/shop/interfaces.py:195
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
@@ -270,7 +274,7 @@ msgid "help_default_shipping_address_step"
 msgstr ""
 
 #. Default: "The subject for order mails."
-#: ./ftw/shop/interfaces.py:174
+#: ./ftw/shop/interfaces.py:178
 msgid "help_mail_subject"
 msgstr ""
 
@@ -284,11 +288,11 @@ msgid "help_order_review_step"
 msgstr ""
 
 #. Default: "Will be displayed in the customer confirmation mail as contact information when configured."
-#: ./ftw/shop/interfaces.py:182
+#: ./ftw/shop/interfaces.py:186
 msgid "help_phone_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:250
+#: ./ftw/shop/interfaces.py:254
 msgid "help_show_status_column"
 msgstr ""
 
@@ -297,15 +301,15 @@ msgstr ""
 msgid "help_supplier_address"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:258
+#: ./ftw/shop/interfaces.py:262
 msgid "help_vat_enabled"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:266
+#: ./ftw/shop/interfaces.py:270
 msgid "help_vat_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:274
+#: ./ftw/shop/interfaces.py:278
 msgid "help_vat_rates"
 msgstr ""
 
@@ -325,7 +329,7 @@ msgid "label_always"
 msgstr ""
 
 #. Default: "Always notify shop owner about orders"
-#: ./ftw/shop/interfaces.py:189
+#: ./ftw/shop/interfaces.py:193
 msgid "label_always_notify_shop_owner"
 msgstr ""
 
@@ -377,18 +381,18 @@ msgid "label_checkout_wizard"
 msgstr ""
 
 #. Default: "City"
-#: ./ftw/shop/interfaces.py:321
+#: ./ftw/shop/interfaces.py:325
 msgid "label_city"
 msgstr ""
 
 #. Default: "Comments"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:329
+#: ./ftw/shop/interfaces.py:333
 msgid "label_comments"
 msgstr ""
 
 #. Default: "Company"
-#: ./ftw/shop/interfaces.py:301
+#: ./ftw/shop/interfaces.py:305
 msgid "label_company"
 msgstr ""
 
@@ -398,12 +402,12 @@ msgid "label_config_variations"
 msgstr ""
 
 #. Default: "Contact Information Step Group"
-#: ./ftw/shop/interfaces.py:220
+#: ./ftw/shop/interfaces.py:224
 msgid "label_contact_info_step_group"
 msgstr ""
 
 #. Default: "Country"
-#: ./ftw/shop/interfaces.py:325
+#: ./ftw/shop/interfaces.py:329
 msgid "label_country"
 msgstr ""
 
@@ -480,12 +484,12 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "Enabled Payment Processors"
-#: ./ftw/shop/interfaces.py:204
+#: ./ftw/shop/interfaces.py:208
 msgid "label_enabled_payment_processors"
 msgstr ""
 
 #. Default: "First Name"
-#: ./ftw/shop/interfaces.py:289
+#: ./ftw/shop/interfaces.py:293
 msgid "label_firstname"
 msgstr ""
 
@@ -507,12 +511,12 @@ msgid "label_included_vat"
 msgstr ""
 
 #. Default: "Last Name"
-#: ./ftw/shop/interfaces.py:293
+#: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr ""
 
 #. Default: "BCC Address"
-#: ./ftw/shop/interfaces.py:167
+#: ./ftw/shop/interfaces.py:171
 msgid "label_mail_bcc"
 msgstr ""
 
@@ -522,7 +526,7 @@ msgid "label_mail_group"
 msgstr ""
 
 #. Default: "Subject"
-#: ./ftw/shop/interfaces.py:172
+#: ./ftw/shop/interfaces.py:176
 msgid "label_mail_subject"
 msgstr ""
 
@@ -557,7 +561,7 @@ msgid "label_order_review_step"
 msgstr ""
 
 #. Default: "Order Review Step Group"
-#: ./ftw/shop/interfaces.py:234
+#: ./ftw/shop/interfaces.py:238
 msgid "label_order_review_step_group"
 msgstr ""
 
@@ -568,18 +572,18 @@ msgid "label_order_status"
 msgstr ""
 
 #. Default: "Order Storage method"
-#: ./ftw/shop/interfaces.py:213
+#: ./ftw/shop/interfaces.py:217
 msgid "label_order_storage"
 msgstr ""
 
 #. Default: "Payment Processor"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:90
-#: ./ftw/shop/interfaces.py:124
+#: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr ""
 
 #. Default: "Payment Processor Step Group"
-#: ./ftw/shop/interfaces.py:197
+#: ./ftw/shop/interfaces.py:201
 msgid "label_payment_processor_step_group"
 msgstr ""
 
@@ -596,7 +600,7 @@ msgid "label_phone"
 msgstr ""
 
 #. Default: "Phone number"
-#: ./ftw/shop/interfaces.py:180
+#: ./ftw/shop/interfaces.py:184
 msgid "label_phone_number"
 msgstr ""
 
@@ -618,7 +622,7 @@ msgid "label_shipping_address"
 msgstr ""
 
 #. Default: "Shipping Address Step Group"
-#: ./ftw/shop/interfaces.py:227
+#: ./ftw/shop/interfaces.py:231
 msgid "label_shipping_address_step_group"
 msgstr ""
 
@@ -628,12 +632,12 @@ msgid "label_shop_configuration"
 msgstr ""
 
 #. Default: "Sender e-Mail Address"
-#: ./ftw/shop/interfaces.py:162
+#: ./ftw/shop/interfaces.py:166
 msgid "label_shop_email"
 msgstr ""
 
 #. Default: "Enter the shop name"
-#: ./ftw/shop/interfaces.py:157
+#: ./ftw/shop/interfaces.py:161
 msgid "label_shop_name"
 msgstr ""
 
@@ -644,7 +648,7 @@ msgid "label_show_price"
 msgstr ""
 
 #. Default: "Show status column in order manager"
-#: ./ftw/shop/interfaces.py:248
+#: ./ftw/shop/interfaces.py:252
 msgid "label_show_status_column"
 msgstr ""
 
@@ -666,17 +670,17 @@ msgid "label_status"
 msgstr ""
 
 #. Default: "Status Set"
-#: ./ftw/shop/interfaces.py:241
+#: ./ftw/shop/interfaces.py:245
 msgid "label_status_set"
 msgstr ""
 
 #. Default: "Street/No."
-#: ./ftw/shop/interfaces.py:305
+#: ./ftw/shop/interfaces.py:309
 msgid "label_street"
 msgstr ""
 
 #. Default: "Address 2"
-#: ./ftw/shop/interfaces.py:309
+#: ./ftw/shop/interfaces.py:313
 msgid "label_street2"
 msgstr ""
 
@@ -708,7 +712,7 @@ msgid "label_supplier_from_parent"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/shop/interfaces.py:285
+#: ./ftw/shop/interfaces.py:289
 msgid "label_title"
 msgstr ""
 
@@ -723,7 +727,7 @@ msgid "label_up_to_shop_setup"
 msgstr ""
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:338
+#: ./ftw/shop/interfaces.py:355
 msgid "label_used"
 msgstr ""
 
@@ -757,7 +761,7 @@ msgid "label_vat"
 msgstr ""
 
 #. Default: "Enable VAT support"
-#: ./ftw/shop/interfaces.py:256
+#: ./ftw/shop/interfaces.py:260
 msgid "label_vat_enabled"
 msgstr ""
 
@@ -767,7 +771,7 @@ msgid "label_vat_group"
 msgstr ""
 
 #. Default: "VAT number"
-#: ./ftw/shop/interfaces.py:264
+#: ./ftw/shop/interfaces.py:268
 msgid "label_vat_number"
 msgstr ""
 
@@ -777,12 +781,12 @@ msgid "label_vat_rate"
 msgstr ""
 
 #. Default: "VAT rates"
-#: ./ftw/shop/interfaces.py:272
+#: ./ftw/shop/interfaces.py:276
 msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Zip Code"
-#: ./ftw/shop/interfaces.py:317
+#: ./ftw/shop/interfaces.py:321
 msgid "label_zipcode"
 msgstr ""
 

--- a/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-08-28 08:45+0000\n"
+"POT-Creation-Date: 2014-09-02 14:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -85,6 +85,10 @@ msgstr ""
 
 #: ./ftw/shop/profiles/default/types/Supplier.xml
 msgid "Supplier"
+msgstr ""
+
+#: ./ftw/shop/interfaces.py:342
+msgid "This email address is invalid."
 msgstr ""
 
 #: ./ftw/shop/portlets/cart.py:112
@@ -257,7 +261,7 @@ msgid "help_add_cart_portlet"
 msgstr ""
 
 #. Default: "Also send eMail to owner if supplier(s) have been notified"
-#: ./ftw/shop/interfaces.py:191
+#: ./ftw/shop/interfaces.py:195
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
@@ -274,7 +278,7 @@ msgid "help_default_shipping_address_step"
 msgstr ""
 
 #. Default: "The subject for order mails."
-#: ./ftw/shop/interfaces.py:174
+#: ./ftw/shop/interfaces.py:178
 msgid "help_mail_subject"
 msgstr ""
 
@@ -288,11 +292,11 @@ msgid "help_order_review_step"
 msgstr ""
 
 #. Default: "Will be displayed in the customer confirmation mail as contact information when configured."
-#: ./ftw/shop/interfaces.py:182
+#: ./ftw/shop/interfaces.py:186
 msgid "help_phone_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:250
+#: ./ftw/shop/interfaces.py:254
 msgid "help_show_status_column"
 msgstr ""
 
@@ -301,15 +305,15 @@ msgstr ""
 msgid "help_supplier_address"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:258
+#: ./ftw/shop/interfaces.py:262
 msgid "help_vat_enabled"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:266
+#: ./ftw/shop/interfaces.py:270
 msgid "help_vat_number"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:274
+#: ./ftw/shop/interfaces.py:278
 msgid "help_vat_rates"
 msgstr ""
 
@@ -329,7 +333,7 @@ msgid "label_always"
 msgstr ""
 
 #. Default: "Always notify shop owner about orders"
-#: ./ftw/shop/interfaces.py:189
+#: ./ftw/shop/interfaces.py:193
 msgid "label_always_notify_shop_owner"
 msgstr ""
 
@@ -381,18 +385,18 @@ msgid "label_checkout_wizard"
 msgstr ""
 
 #. Default: "City"
-#: ./ftw/shop/interfaces.py:321
+#: ./ftw/shop/interfaces.py:325
 msgid "label_city"
 msgstr ""
 
 #. Default: "Comments"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:329
+#: ./ftw/shop/interfaces.py:333
 msgid "label_comments"
 msgstr ""
 
 #. Default: "Company"
-#: ./ftw/shop/interfaces.py:301
+#: ./ftw/shop/interfaces.py:305
 msgid "label_company"
 msgstr ""
 
@@ -402,12 +406,12 @@ msgid "label_config_variations"
 msgstr ""
 
 #. Default: "Contact Information Step Group"
-#: ./ftw/shop/interfaces.py:220
+#: ./ftw/shop/interfaces.py:224
 msgid "label_contact_info_step_group"
 msgstr ""
 
 #. Default: "Country"
-#: ./ftw/shop/interfaces.py:325
+#: ./ftw/shop/interfaces.py:329
 msgid "label_country"
 msgstr ""
 
@@ -484,12 +488,12 @@ msgid "label_email"
 msgstr ""
 
 #. Default: "Enabled Payment Processors"
-#: ./ftw/shop/interfaces.py:204
+#: ./ftw/shop/interfaces.py:208
 msgid "label_enabled_payment_processors"
 msgstr ""
 
 #. Default: "First Name"
-#: ./ftw/shop/interfaces.py:289
+#: ./ftw/shop/interfaces.py:293
 msgid "label_firstname"
 msgstr ""
 
@@ -511,12 +515,12 @@ msgid "label_included_vat"
 msgstr ""
 
 #. Default: "Last Name"
-#: ./ftw/shop/interfaces.py:293
+#: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr ""
 
 #. Default: "BCC Address"
-#: ./ftw/shop/interfaces.py:167
+#: ./ftw/shop/interfaces.py:171
 msgid "label_mail_bcc"
 msgstr ""
 
@@ -526,7 +530,7 @@ msgid "label_mail_group"
 msgstr ""
 
 #. Default: "Subject"
-#: ./ftw/shop/interfaces.py:172
+#: ./ftw/shop/interfaces.py:176
 msgid "label_mail_subject"
 msgstr ""
 
@@ -561,7 +565,7 @@ msgid "label_order_review_step"
 msgstr ""
 
 #. Default: "Order Review Step Group"
-#: ./ftw/shop/interfaces.py:234
+#: ./ftw/shop/interfaces.py:238
 msgid "label_order_review_step_group"
 msgstr ""
 
@@ -572,18 +576,18 @@ msgid "label_order_status"
 msgstr ""
 
 #. Default: "Order Storage method"
-#: ./ftw/shop/interfaces.py:213
+#: ./ftw/shop/interfaces.py:217
 msgid "label_order_storage"
 msgstr ""
 
 #. Default: "Payment Processor"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:90
-#: ./ftw/shop/interfaces.py:124
+#: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr ""
 
 #. Default: "Payment Processor Step Group"
-#: ./ftw/shop/interfaces.py:197
+#: ./ftw/shop/interfaces.py:201
 msgid "label_payment_processor_step_group"
 msgstr ""
 
@@ -600,7 +604,7 @@ msgid "label_phone"
 msgstr ""
 
 #. Default: "Phone number"
-#: ./ftw/shop/interfaces.py:180
+#: ./ftw/shop/interfaces.py:184
 msgid "label_phone_number"
 msgstr ""
 
@@ -622,7 +626,7 @@ msgid "label_shipping_address"
 msgstr ""
 
 #. Default: "Shipping Address Step Group"
-#: ./ftw/shop/interfaces.py:227
+#: ./ftw/shop/interfaces.py:231
 msgid "label_shipping_address_step_group"
 msgstr ""
 
@@ -632,12 +636,12 @@ msgid "label_shop_configuration"
 msgstr ""
 
 #. Default: "Sender e-Mail Address"
-#: ./ftw/shop/interfaces.py:162
+#: ./ftw/shop/interfaces.py:166
 msgid "label_shop_email"
 msgstr ""
 
 #. Default: "Enter the shop name"
-#: ./ftw/shop/interfaces.py:157
+#: ./ftw/shop/interfaces.py:161
 msgid "label_shop_name"
 msgstr ""
 
@@ -648,7 +652,7 @@ msgid "label_show_price"
 msgstr ""
 
 #. Default: "Show status column in order manager"
-#: ./ftw/shop/interfaces.py:248
+#: ./ftw/shop/interfaces.py:252
 msgid "label_show_status_column"
 msgstr ""
 
@@ -670,17 +674,17 @@ msgid "label_status"
 msgstr ""
 
 #. Default: "Status Set"
-#: ./ftw/shop/interfaces.py:241
+#: ./ftw/shop/interfaces.py:245
 msgid "label_status_set"
 msgstr ""
 
 #. Default: "Street/No."
-#: ./ftw/shop/interfaces.py:305
+#: ./ftw/shop/interfaces.py:309
 msgid "label_street"
 msgstr ""
 
 #. Default: "Address 2"
-#: ./ftw/shop/interfaces.py:309
+#: ./ftw/shop/interfaces.py:313
 msgid "label_street2"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgid "label_supplier_from_parent"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/shop/interfaces.py:285
+#: ./ftw/shop/interfaces.py:289
 msgid "label_title"
 msgstr ""
 
@@ -727,7 +731,7 @@ msgid "label_up_to_shop_setup"
 msgstr ""
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:338
+#: ./ftw/shop/interfaces.py:355
 msgid "label_used"
 msgstr ""
 
@@ -761,7 +765,7 @@ msgid "label_vat"
 msgstr ""
 
 #. Default: "Enable VAT support"
-#: ./ftw/shop/interfaces.py:256
+#: ./ftw/shop/interfaces.py:260
 msgid "label_vat_enabled"
 msgstr ""
 
@@ -771,7 +775,7 @@ msgid "label_vat_group"
 msgstr ""
 
 #. Default: "VAT number"
-#: ./ftw/shop/interfaces.py:264
+#: ./ftw/shop/interfaces.py:268
 msgid "label_vat_number"
 msgstr ""
 
@@ -781,12 +785,12 @@ msgid "label_vat_rate"
 msgstr ""
 
 #. Default: "VAT rates"
-#: ./ftw/shop/interfaces.py:272
+#: ./ftw/shop/interfaces.py:276
 msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Zip Code"
-#: ./ftw/shop/interfaces.py:317
+#: ./ftw/shop/interfaces.py:321
 msgid "label_zipcode"
 msgstr ""
 

--- a/ftw/shop/tests/test_browser_checkout.py
+++ b/ftw/shop/tests/test_browser_checkout.py
@@ -51,6 +51,18 @@ class TestBrowserCheckout(TestCase):
             z3cform.erroneous_fields(form))
 
     @browsing
+    def test_valid_email_address_required(self, browser):
+        checkout.visit_checkout_with_one_item_in_cart()
+        browser.fill({'Email': 'invalid.email.ch'})
+        checkout.next()
+        checkout.assert_step(checkout.CONTACT_INFORMATION)
+
+        form = browser.css('form.kssattr-formname-checkout-wizard').first
+        self.assertEquals(
+            ['This email address is invalid.'],
+            z3cform.erroneous_fields(form)[u'Email'])
+
+    @browsing
     def test_contact_information_defaults_for_logged_in_user(self, browser):
         hugo = create(Builder('user').named('H\xc3\xbcgo', 'B\xc3\xb6ss'))
         browser.login(hugo)

--- a/ftw/shop/tests/test_utils.py
+++ b/ftw/shop/tests/test_utils.py
@@ -1,15 +1,15 @@
-import unittest
 from decimal import Decimal
-from ftw.shop.utils import to_decimal
-
 from ftw.shop.tests.base import FtwShopTestCase
+from ftw.shop.utils import to_decimal
+from ftw.shop.utils import is_email_valid
+from unittest2 import TestCase
 
 
 class TestUtils(FtwShopTestCase):
-    
+
     def afterSetUp(self):
         super(TestUtils, self).afterSetUp()
- 
+
     def test_to_decimal(self):
         self.assertEquals(to_decimal('10.00'), Decimal('10.00'))
         self.assertEquals(to_decimal('123'), Decimal('123.00'))
@@ -21,7 +21,32 @@ class TestUtils(FtwShopTestCase):
         self.assertEquals(to_decimal(Decimal('0E-10')), Decimal('0.00'))
 
 
-def test_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(TestUtils))
-    return suite
+class TestIsEmailValid(TestCase):
+
+    def test_valid_addresses(self):
+        self.assert_valid_email('john@doe.com')
+        self.assert_valid_email('john.doe@gmail.com')
+        self.assert_valid_email('j@doe.com')
+        self.assert_valid_email('j.d@doe.com')
+        self.assert_valid_email('me@john.doe.com')
+        self.assert_valid_email('x@y.z')
+
+    def test_invalid_addresses(self):
+        self.assert_invalid_email('john@doe@gmail.com')
+        self.assert_invalid_email('john.@gmail.com')
+        self.assert_invalid_email('john@.gmail.com')
+        self.assert_invalid_email('john@localhost')
+
+    def assert_valid_email(self, address, msg=''):
+        message = 'Expected email {0} to be valid'.format(address)
+        if msg:
+            message = ': '.join((message, msg))
+        self.assertTrue(is_email_valid(address),
+                        message)
+
+    def assert_invalid_email(self, address, msg=''):
+        message = 'Expected email {0} to be invalid'.format(address)
+        if msg:
+            message = ': '.join((message, msg))
+        self.assertFalse(is_email_valid(address),
+                         message)

--- a/ftw/shop/utils.py
+++ b/ftw/shop/utils.py
@@ -3,6 +3,7 @@ from decimal import InvalidOperation
 import codecs
 import cStringIO
 import csv
+import re
 
 
 def to_decimal(number):
@@ -21,6 +22,11 @@ def to_decimal(number):
         return Decimal(str(number)[:str(number).find('.') + 3])
     except InvalidOperation:
         return number
+
+
+def is_email_valid(address):
+    expr = re.compile(r'^[^@]*[^@\.]@[^@\.][^@]*\.[^@]+$', re.IGNORECASE)
+    return bool(expr.match(address))
 
 
 class UnicodeCSVWriter:


### PR DESCRIPTION
Adds validation for the email address.

I've added a very simple regex check for the email address, since the more complex checks usually do not allow valid but exotic email addresses.
The simple check is that the address contains exactly one `@`, which is not followed or preceded by a `.`. It should also contain at least one `.` in the domain part of the address.

@lukasgraf could you take a look?
