### PR TITLE
Fix getting the uid in get_suppliers, if there are variations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.5 (unreleased)
 ------------------
 
+- Fix getting the uid in get_suppliers, if there are variations.
+  [mathias.leimgruber]
+
 - Fill content-core slot instead of main slot in shopitem view. Fixes #10
   [erral]
 

--- a/ftw/shop/browser/cart.py
+++ b/ftw/shop/browser/cart.py
@@ -116,7 +116,9 @@ class ShoppingCartAdapter(object):
 
         for itemkey, itemvalue in self.get_items().items():
             if 'variation_code' in itemvalue:
-                uid = itemkey.rstrip(itemvalue['variation_code'].strip('var'))
+                # Strip of variation suffix from itemkey to get the uid.
+                variation_suffix = itemvalue['variation_code'].strip('var')
+                uid = itemkey[:-len(variation_suffix)]
             else:
                 uid = itemkey
 


### PR DESCRIPTION
rstrip is the wrong solution, since it strips of every char.

Example:

UID with variation suffix - important part is the "0" on position -2
bfdf53b2009e4c1d9c56ebef20a85a9**0**-0

Old solution did a rstrip of the variation part "-0"

	>>> bfdf53b2009e4c1d9c56ebef20a85a90-0.rstrip('-0')
	bfdf53b2009e4c1d9c56ebef20a85a9  # 	Which results in a wrong uid

The right uid woul be "bfdf53b2009e4c1d9c56ebef20a85a90", including the last "0"