### PR TITLE
Simplify browser resources

### DIFF
--- a/ftw/shop/browser/configure.zcml
+++ b/ftw/shop/browser/configure.zcml
@@ -5,11 +5,11 @@
 
   <include package="plone.app.contentmenu" />
   <include package=".widgets" file="paymentprocessor.zcml"/>
-  
+
   <include file="cart.zcml" />
   <include file="mail.zcml" />
 
-  <!-- Shop Items --> 
+  <!-- Shop Items -->
   <browser:page
     for="..interfaces.IShopItem"
     name="view"
@@ -23,7 +23,7 @@
     permission="zope2.View"
     class=".shopitem.ShopCompactItemView"
     />
-    
+
   <browser:menuItem
     for="..interfaces.IShopItem"
     menu="plone_displayviews"
@@ -38,8 +38,8 @@
     permission="zope2.View"
     class=".shopitem.EditVariationsView"
     />
-    
-  <!-- Shop Categories --> 
+
+  <!-- Shop Categories -->
   <browser:page
     for="..interfaces.IShopCategory"
     name="view"
@@ -53,7 +53,7 @@
     permission="zope2.View"
     class=".category.CategoryView"
     />
-    
+
   <browser:page
     for="..interfaces.IShopCategory"
     name="compact_view"
@@ -99,7 +99,7 @@
     action="compact_view"
     description=""
     />
-    
+
   <!-- Order Manager View -->
   <browser:page
     for="plone.app.layout.navigation.interfaces.INavigationRoot"
@@ -117,11 +117,11 @@
     class=".ordermanager.OrderView"
     />
 
-  <browser:page 
+  <browser:page
     for="*"
-    name="edit_categories" 
+    name="edit_categories"
     class=".manage_categories.ManageCategories"
-    permission="cmf.ModifyPortalContent" 
+    permission="cmf.ModifyPortalContent"
     />
 
   <browser:page
@@ -185,33 +185,7 @@
 
   <browser:resourceDirectory
     name='ftw-shop-resources'
-    directory="resources" 
-    />
-
-  <browser:resource
-    name="ftw_shop.css"
-    file="resources/ftw_shop.css"
-    />
-
-  <browser:resource
-    name="shop.js"
-    file="resources/shop.js"
-    />
-
-  <browser:resource
-    name="shop_config.js"
-    file="resources/shop_config.js"
-    />
-
-  <browser:resource
-    name="contactform_prefill.js"
-    file="resources/contactform_prefill.js"
-    />
-
-
-  <browser:resource
-    name="jquery-ui-i18n-manual.js"
-    file="resources/jquery-ui-i18n-manual.js"
+    directory="resources"
     />
 
 </configure>

--- a/ftw/shop/browser/templates/cart_edit.pt
+++ b/ftw/shop/browser/templates/cart_edit.pt
@@ -64,8 +64,7 @@
                           <a href="" tal:attributes="href python:'cart_remove?skuCode=%s' % skuCode"
                                      i18n:attributes="cart_remove">
                               <img tal:define="portal_url context/@@plone_portal_state/portal_url"
-                                  tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/delete_p.gif"
-                                src="++resource++ftw-shop-resources/delete_p.gif" />
+                                  tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/delete_p.gif" />
                           </a>
                       </td>
                     </tr>

--- a/ftw/shop/browser/templates/cart_edit.pt
+++ b/ftw/shop/browser/templates/cart_edit.pt
@@ -12,15 +12,15 @@
                             cart cview/cart_items">
 
     <h1 i18n:translate="cart_title">Shopping Cart</h1>
-    
+
     <tal:block tal:define="cart_items python:cart.values()">
-                           
+
         <p tal:condition="not:cart_items"
            i18n:translate="cart_is_empty">Your cart is empty</p>
-           
+
         <form method="post" action="./"
               tal:condition="cart_items">
-              
+
             <table class="cartListing listing" cellpadding="0" cellspacing="0">
                 <thead>
                   <tr>
@@ -63,10 +63,12 @@
                       <td>
                           <a href="" tal:attributes="href python:'cart_remove?skuCode=%s' % skuCode"
                                      i18n:attributes="cart_remove">
-                              <img src="++resource++ftw-shop-resources/delete_p.gif" />
+                              <img tal:define="portal_url context/@@plone_portal_state/portal_url"
+                                  tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/delete_p.gif"
+                                src="++resource++ftw-shop-resources/delete_p.gif" />
                           </a>
                       </td>
-                    </tr> 
+                    </tr>
                   </metal:block>
                 </tbody>
               </table>

--- a/ftw/shop/browser/templates/category.pt
+++ b/ftw/shop/browser/templates/category.pt
@@ -116,8 +116,7 @@
 
     <script type="text/javascript"
         tal:define="portal_url context/@@plone_portal_state/portal_url"
-        tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"
-        src="++resource++ftw-shop-resources/shop.js"></script>
+        tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"></script>
 
     <div tal:replace="structure provider:plone.belowcontentbody" />
 

--- a/ftw/shop/browser/templates/category.pt
+++ b/ftw/shop/browser/templates/category.pt
@@ -18,7 +18,7 @@
 
         <div tal:replace="structure provider:plone.abovecontenttitle" />
 
-        <h1 class="documentFirstHeading" tal:content="context/Title"> 
+        <h1 class="documentFirstHeading" tal:content="context/Title">
             <metal:field use-macro="python:here.widget('Title', mode='view')">
             Title
             </metal:field>
@@ -114,7 +114,10 @@
 
     </tal:shopitems>
 
-    <script type="text/javascript" src="++resource++shop.js"></script>
+    <script type="text/javascript"
+        tal:define="portal_url context/@@plone_portal_state/portal_url"
+        tal:attributes="src string:${portal_url}/++resource++shop.js"
+        src="++resource++shop.js"></script>
 
     <div tal:replace="structure provider:plone.belowcontentbody" />
 

--- a/ftw/shop/browser/templates/category.pt
+++ b/ftw/shop/browser/templates/category.pt
@@ -116,8 +116,8 @@
 
     <script type="text/javascript"
         tal:define="portal_url context/@@plone_portal_state/portal_url"
-        tal:attributes="src string:${portal_url}/++resource++shop.js"
-        src="++resource++shop.js"></script>
+        tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"
+        src="++resource++ftw-shop-resources/shop.js"></script>
 
     <div tal:replace="structure provider:plone.belowcontentbody" />
 

--- a/ftw/shop/browser/templates/checkout-wizard.pt
+++ b/ftw/shop/browser/templates/checkout-wizard.pt
@@ -54,6 +54,5 @@
   </tal:form>
   <script type="text/javascript"
     tal:define="portal_url context/@@plone_portal_state/portal_url"
-    tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/contactform_prefill.js"
-    src="++resource++ftw-shop-resources/contactform_prefill.js"></script>
+    tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/contactform_prefill.js"></script>
 </div>

--- a/ftw/shop/browser/templates/checkout-wizard.pt
+++ b/ftw/shop/browser/templates/checkout-wizard.pt
@@ -54,6 +54,6 @@
   </tal:form>
   <script type="text/javascript"
     tal:define="portal_url context/@@plone_portal_state/portal_url"
-    tal:attributes="src string:${portal_url}/++resource++contactform_prefill.js"
-    src="++resource++contactform_prefill.js"></script>
+    tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/contactform_prefill.js"
+    src="++resource++ftw-shop-resources/contactform_prefill.js"></script>
 </div>

--- a/ftw/shop/browser/templates/checkout-wizard.pt
+++ b/ftw/shop/browser/templates/checkout-wizard.pt
@@ -52,5 +52,8 @@
       </form>
 
   </tal:form>
-  <script type="text/javascript" src="++resource++contactform_prefill.js"></script>
+  <script type="text/javascript"
+    tal:define="portal_url context/@@plone_portal_state/portal_url"
+    tal:attributes="src string:${portal_url}/++resource++contactform_prefill.js"
+    src="++resource++contactform_prefill.js"></script>
 </div>

--- a/ftw/shop/browser/templates/edit_variations.pt
+++ b/ftw/shop/browser/templates/edit_variations.pt
@@ -5,7 +5,10 @@
 
     <head>
         <metal:js fill-slot="javascript_head_slot">
-            <script type="text/javascript" src="++resource++ftw-shop-resources/edit_variations.js"></script>
+            <script type="text/javascript"
+                tal:define="portal_url context/@@plone_portal_state/portal_url"
+                tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/edit_variations.js"
+                src="++resource++ftw-shop-resources/edit_variations.js"></script>
         </metal:js>
     </head>
 

--- a/ftw/shop/browser/templates/edit_variations.pt
+++ b/ftw/shop/browser/templates/edit_variations.pt
@@ -7,8 +7,7 @@
         <metal:js fill-slot="javascript_head_slot">
             <script type="text/javascript"
                 tal:define="portal_url context/@@plone_portal_state/portal_url"
-                tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/edit_variations.js"
-                src="++resource++ftw-shop-resources/edit_variations.js"></script>
+                tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/edit_variations.js"></script>
         </metal:js>
     </head>
 

--- a/ftw/shop/browser/templates/order_manager.pt
+++ b/ftw/shop/browser/templates/order_manager.pt
@@ -130,7 +130,10 @@
            <input i18n:attributes="value" type="submit" name="cancel_orders" value="Delete orders">
         </p>
 
-        <script type="text/javascript" src="++resource++jquery-ui-i18n-manual.js"></script>
+        <script type="text/javascript"
+            tal:define="portal_url context/@@plone_portal_state/portal_url"
+            tal:attributes="src string:${portal_url}/++resource++jquery-ui-i18n-manual.js"
+            src="++resource++jquery-ui-i18n-manual.js"></script>
         <script>
             jQuery(function($) {
                 //read out language cookie

--- a/ftw/shop/browser/templates/order_manager.pt
+++ b/ftw/shop/browser/templates/order_manager.pt
@@ -132,8 +132,7 @@
 
         <script type="text/javascript"
             tal:define="portal_url context/@@plone_portal_state/portal_url"
-            tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/jquery-ui-i18n-manual.js"
-            src="++resource++ftw-shop-resources/jquery-ui-i18n-manual.js"></script>
+            tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/jquery-ui-i18n-manual.js"></script>
         <script>
             jQuery(function($) {
                 //read out language cookie

--- a/ftw/shop/browser/templates/order_manager.pt
+++ b/ftw/shop/browser/templates/order_manager.pt
@@ -132,8 +132,8 @@
 
         <script type="text/javascript"
             tal:define="portal_url context/@@plone_portal_state/portal_url"
-            tal:attributes="src string:${portal_url}/++resource++jquery-ui-i18n-manual.js"
-            src="++resource++jquery-ui-i18n-manual.js"></script>
+            tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/jquery-ui-i18n-manual.js"
+            src="++resource++ftw-shop-resources/jquery-ui-i18n-manual.js"></script>
         <script>
             jQuery(function($) {
                 //read out language cookie

--- a/ftw/shop/browser/templates/shopitem.pt
+++ b/ftw/shop/browser/templates/shopitem.pt
@@ -47,8 +47,7 @@
 
         <script type="text/javascript"
           tal:define="portal_url context/@@plone_portal_state/portal_url"
-          tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"
-          src="++resource++ftw-shop-resources/shop.js"></script>
+          tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"></script>
 
     </tal:content-core-macro>
 </metal:content-core>

--- a/ftw/shop/browser/templates/shopitem.pt
+++ b/ftw/shop/browser/templates/shopitem.pt
@@ -47,8 +47,8 @@
 
         <script type="text/javascript"
           tal:define="portal_url context/@@plone_portal_state/portal_url"
-          tal:attributes="src string:${portal_url}/++resource++shop.js"
-          src="++resource++shop.js"></script>
+          tal:attributes="src string:${portal_url}/++resource++ftw-shop-resources/shop.js"
+          src="++resource++ftw-shop-resources/shop.js"></script>
 
     </tal:content-core-macro>
 </metal:content-core>

--- a/ftw/shop/browser/templates/shopitem.pt
+++ b/ftw/shop/browser/templates/shopitem.pt
@@ -45,7 +45,10 @@
 
         </tal:shopitems>
 
-        <script type="text/javascript" src="++resource++shop.js"></script>
+        <script type="text/javascript"
+          tal:define="portal_url context/@@plone_portal_state/portal_url"
+          tal:attributes="src string:${portal_url}/++resource++shop.js"
+          src="++resource++shop.js"></script>
 
     </tal:content-core-macro>
 </metal:content-core>

--- a/ftw/shop/profiles/default/cssregistry.xml
+++ b/ftw/shop/profiles/default/cssregistry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <object name="portal_css">
     <stylesheet title="" cacheable="True" compression="safe" cookable="True"
-        enabled="1" expression="" id="++resource++ftw_shop.css"
+        enabled="1" expression="" id="++resource++ftw-shop-resources/ftw_shop.css"
         media="screen" rel="stylesheet" rendering="import"/>
 </object>

--- a/ftw/shop/profiles/default/jsregistry.xml
+++ b/ftw/shop/profiles/default/jsregistry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
 <javascript cacheable="True" compression="none" cookable="True"
-            enabled="True" expression="" id="++resource++shop_config.js" inline="False"/>
+            enabled="True" expression="" id="++resource++ftw-shop-resources/shop_config.js" inline="False"/>
 </object>

--- a/ftw/shop/profiles/default/metadata.xml
+++ b/ftw/shop/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-    <version>2000</version>
+    <version>2001</version>
 </metadata>

--- a/ftw/shop/upgrades/configure.zcml
+++ b/ftw/shop/upgrades/configure.zcml
@@ -44,4 +44,14 @@
         profile="ftw.shop:default"
         />
 
+    <!-- 2000 -> 2001 -->
+    <upgrade-step:importProfile
+        title="Register CSS and JS from the resourceDirectory"
+        description=""
+        source="2000"
+        destination="2001"
+        profile="ftw.shop:default"
+        directory="profiles/2001"
+        />
+
 </configure>

--- a/ftw/shop/upgrades/profiles/2001/cssregistry.xml
+++ b/ftw/shop/upgrades/profiles/2001/cssregistry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_css">
+    <stylesheet title="" cacheable="True" compression="safe" cookable="True"
+        remove="True"
+        enabled="1" expression="" id="++resource++ftw_shop.css"
+        media="screen" rel="stylesheet" rendering="import"/>
+    <stylesheet title="" cacheable="True" compression="safe" cookable="True"
+        enabled="1" expression="" id="++resource++ftw-shop-resources/ftw_shop.css"
+        media="screen" rel="stylesheet" rendering="import"/>
+</object>

--- a/ftw/shop/upgrades/profiles/2001/jsregistry.xml
+++ b/ftw/shop/upgrades/profiles/2001/jsregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+<javascript cacheable="True" compression="none" cookable="True"
+            remove="True"
+            enabled="True" expression="" id="++resource++shop_config.js" inline="False"/>
+<javascript cacheable="True" compression="none" cookable="True"
+            enabled="True" expression="" id="++resource++ftw-shop-resources/shop_config.js" inline="False"/>
+</object>


### PR DESCRIPTION
I changed all references to browser resources to be made to the resource directory, instead of using sometimes the resource directory and other times the registered individual resources.

I also changed the references to the resources to be loaded from the portal root.

I also provide an upgrade step to upgrade the profile and the CSS and JS files registered in portal_css and portal_javascripts