### PR TITLE
Fix "Unknown directive.. directory" error.

### DIFF
--- a/ftw/shop/configure.zcml
+++ b/ftw/shop/configure.zcml
@@ -33,6 +33,7 @@
 
     <include package="plone.app.z3cform" />
     <include package="plone.app.registry" />
+    <include package="ftw.upgrade" file="meta.zcml" />
 
     <!-- Include the sub-packages that use their own configure.zcml files. -->
     <include package=".browser" />


### PR DESCRIPTION
When using "upgrade-step:directory", the ``meta.zcm`` of ``ftw.upgrade`` must be loaded first.
This may be done automatically because of z3c.autoinclude, but is in fact random.

Otherwise this error may occur:
```
ZopeXMLConfigurationError: File "/var/lib/jenkins/jobs/wetzikon.policy-master-test-plone-4.3.2.cfg/workspace/src/ftw.shop/ftw/shop/configure.zcml", line 53.4
ConfigurationError: ('Unknown directive', u'http://namespaces.zope.org/ftw.upgrade', u'directory')
```