### PR TITLE
Fix variation js to respect current item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.7 (unreleased)
 ------------------
 
+- Fixed variation js bug.
+  [lknoepfel]
+
 - Fixed bug in edit variations where variations didn't get activated.
   [lknoepfel]
 

--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -80,8 +80,8 @@ jQuery(function ($) {
         }
         else {
             // We've got two variations
-            var var1choice = $('select[name="var1choice"] option:selected').attr("value");
-            var var2choice = $('select[name="var2choice"] option:selected').attr("value");
+            var var1choice = $(this).parents('form').find('select[name="var1choice"] option:selected').attr("value");
+            var var2choice = $(this).parents('form').find('select[name="var2choice"] option:selected').attr("value");
             varcode = "var-" + var1choice + "-" + var2choice;
 
             // Grey out variations that are deactivated
@@ -109,7 +109,7 @@ jQuery(function ($) {
                     }
                 });
                 // restore selection
-                $('select[name="var1choice"] option[value="'+var1choice+'"]').attr('selected', 'selected');
+                $(this).parents('form').find('select[name="var1choice"] option[value="'+var1choice+'"]').attr('selected', 'selected');
 
             }
             else {
@@ -130,7 +130,7 @@ jQuery(function ($) {
                     }
                 });
                 // restore selection
-                $('select[name="var2choice"] option[value="'+var2choice+'"]').attr('selected', 'selected');
+                $(this).parents('form').find('select[name="var2choice"] option[value="'+var2choice+'"]').attr('selected', 'selected');
             }
         }
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='ftw.shop',
       install_requires=[
         'collective.js.jqueryui',
         'collective.z3cform.wizard',
-        'ftw.upgrade',
+        'ftw.upgrade >= 1.14.5',
         'plone.api',
         'plone.app.registry',
         'plone.app.z3cform',


### PR DESCRIPTION
Globalization is evil - respect your parents to find yourself.

Steps to reproduce this bug:

* Create a shop category
* Add a shop item (edit its price, show price)
* Add two variations of this item (edit prices and titles)
* Duplicate the item, modify the prices of the variations
* Go the shop overview, start changing the values and observe the select fields