### PR TITLE
fix shopitem view with 1 and 2 variations

### DIFF
--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -40,11 +40,34 @@ jQuery(function ($) {
         else {
             // Get the containing form's action URL
             url = $(this).parent().attr('action');
-            // Get skuCode and quantity from adjacent input fields
-            itemdata = {
-                skuCode: $(this).parents('form').find('input[name="skuCode"]').val(),
-                quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
-            };
+            var var1choice = $(this).parent().find('input[name="varchoice1"]').val()
+            var var2choice = $(this).parent().find('input[name="varchoice2"]').val()
+            var itemdata;
+            if (var1choice == undefined) {
+                // We don't have variations - reference the item by its skuCode
+                // Get skuCode and quantity from adjacent input fields
+                itemdata = {
+                    skuCode: $(this).parents('form').find('input[name="skuCode"]').val(),
+                    quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
+                };
+            }
+            else {
+                if (var2choice == undefined) {
+                    // We've got one variation
+                    itemdata = {
+                        var1choice: var1choice,
+                        quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
+                    };
+                }
+                else {
+                    // We've got two variations
+                    itemdata = {
+                        var1choice: var1choice,
+                        var2choice: var2choice,
+                        quantity: $(this).parents('form').find('input[name="quantity:int"]').val()
+                    };
+                }
+            }
         }
 
         $.ajax({

--- a/ftw/shop/browser/templates/listing/one_variation.pt
+++ b/ftw/shop/browser/templates/listing/one_variation.pt
@@ -15,11 +15,11 @@
                          </thead>
                          <tbody>
                              <tal:block tal:repeat="varValue1 varConf/getVariation1Values">
-                                 <tr tal:define="active python:varConf.getVariationData(varValue1, None, 'active');
-                                              skuCode python:varConf.getVariationData(varValue1, None, 'skuCode');
-                                              price python:varConf.getVariationData(varValue1, None, 'price');
-                                              description python:varConf.getVariationData(varValue1, None, 'description');
-                                              hasUniqueSKU python:varConf.getVariationData(varValue1, None, 'hasUniqueSKU')"
+                                 <tr tal:define="active python:varConf.getVariationData(repeat['varValue1'].index, None, 'active');
+                                              skuCode python:varConf.getVariationData(repeat['varValue1'].index, None, 'skuCode');
+                                              price python:varConf.getVariationData(repeat['varValue1'].index, None, 'price');
+                                              description python:varConf.getVariationData(repeat['varValue1'].index, None, 'description');
+                                              hasUniqueSKU python:varConf.getVariationData(repeat['varValue1'].index, None, 'hasUniqueSKU')"
                                      tal:condition="active">
                                      <td tal:content="varValue1">S</td>
                                      <td tal:condition="python: not varConf.allPricesZero() and item['showPrice']">CHF <span tal:content="price"/></td>
@@ -37,9 +37,10 @@
                                          </dl>
 
                                          <form tal:condition="varConf/isValid" tal:attributes="action string:${item/url}/addtocart">
+                                             <input type="hidden" name="varchoice1" tal:attributes="value repeat/varValue1/index"/>
                                              <input type="hidden" name="skuCode" tal:attributes="value skuCode"/>
                                              <input type="text" size="2" name="quantity:int" value="1"/>
-                                             <input class="allowMultiSubmit" name="addtocart" type="submit" 
+                                             <input class="allowMultiSubmit" name="addtocart" type="submit"
                                                     value="Add to cart" i18n:attributes="value" />
                                          </form>
                                      </td>

--- a/ftw/shop/browser/templates/listing/two_variations.pt
+++ b/ftw/shop/browser/templates/listing/two_variations.pt
@@ -15,11 +15,11 @@
                         </thead>
                         <tbody>
                             <tal:block tal:repeat="varValue2 varConf/getVariation2Values">
-                                <tr tal:define="active python:varConf.getVariationData(varValue1, varValue2, 'active');
-                                             skuCode python:varConf.getVariationData(varValue1, varValue2, 'skuCode');
-                                             price python:varConf.getVariationData(varValue1, varValue2, 'price');
-                                             description python:varConf.getVariationData(varValue1, varValue2, 'description');
-                                             hasUniqueSKU python:varConf.getVariationData(varValue1, varValue2, 'hasUniqueSKU')"
+                                <tr tal:define="active python:varConf.getVariationData(repeat['varValue1'].index, repeat['varValue2'].index, 'active');
+                                             skuCode python:varConf.getVariationData(repeat['varValue1'].index, repeat['varValue2'].index, 'skuCode');
+                                             price python:varConf.getVariationData(repeat['varValue1'].index, repeat['varValue2'].index, 'price');
+                                             description python:varConf.getVariationData(repeat['varValue1'].index, repeat['varValue2'].index, 'description');
+                                             hasUniqueSKU python:varConf.getVariationData(repeat['varValue1'].index, repeat['varValue2'].index, 'hasUniqueSKU')"
                                     tal:condition="active">
                                     <td tal:content="varValue2">S</td>
                                     <td tal:condition="python: not varConf.allPricesZero() and item['showPrice']">CHF <span tal:content="price"/></td>
@@ -36,6 +36,8 @@
                                         </dl>
 
                                         <form tal:condition="varConf/isValid" tal:attributes="action string:${item/url}/addtocart">
+                                            <input type="hidden" name="varchoice1" tal:attributes="value repeat/varValue1/index"/>
+                                            <input type="hidden" name="varchoice2" tal:attributes="value repeat/varValue2/index"/>
                                             <input type="hidden" name="skuCode" tal:attributes="value skuCode"/>
                                             <input type="text" size="2" name="quantity:int" value="1"/>
                                             <input name="addtocart" class="allowMultiSubmit" type="submit"


### PR DESCRIPTION
The 'view' view of shopitem when the item has 1 or 2 variations does not work correctly:
- No information about the variation is shown
- The Add-to-cart Javascript does not work

With these changes everything is working as in 'compact_view'