### PR TITLE
Parse always the variation information in edit variations forms

### DIFF
--- a/ftw/shop/browser/shopitem.py
+++ b/ftw/shop/browser/shopitem.py
@@ -384,22 +384,22 @@ class EditVariationsView(BrowserView):
         def _parse_data(variation_code):
             data = {}
             data['active'] = bool(form.get("%s-active" % variation_code))
-            if data['active']:
-                # TODO: Handle decimal more elegantly
-                price = form.get("%s-price" % variation_code)
-                try:
-                    p = int(price)
-                    # Create a tuple of ints from string
-                    digits = tuple([int(i) for i in list(str(p))]) + (0, 0)
-                    data['price'] = Decimal((0, digits, -2))
-                except ValueError:
-                    if not price == "":
-                        data['price'] = Decimal(price)
-                    else:
-                        data['price'] = Decimal("0.00")
 
-                data['skuCode'] = form.get("%s-skuCode" % variation_code)
-                data['description'] = form.get("%s-description" % variation_code)
+            # TODO: Handle decimal more elegantly
+            price = form.get("%s-price" % variation_code)
+            try:
+                p = int(price)
+                # Create a tuple of ints from string
+                digits = tuple([int(i) for i in list(str(p))]) + (0, 0)
+                data['price'] = Decimal((0, digits, -2))
+            except ValueError:
+                if not price == "":
+                    data['price'] = Decimal(price)
+                else:
+                    data['price'] = Decimal("0.00")
+
+            data['skuCode'] = form.get("%s-skuCode" % variation_code)
+            data['description'] = form.get("%s-description" % variation_code)
 
             # At this point the form has already been validated,
             # so uniqueness of sku codes is ensured


### PR DESCRIPTION
With the if data['active'] check, only data of the enabled variations is saved. After this change, the information (price, description, SKU) is kept, and only the active/inactive information is changed.

@libargutxi
