### PR TITLE
Save variations as a mapping to annotation storage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make variations a mapping when saving to the annotation storage.
+  [raphael-s]
 
 
 2.0.9 (2016-11-11)

--- a/ftw/shop/upgrades/20161125174053_convert_variations_to_mapping_in_annotation_storage/upgrade.py
+++ b/ftw/shop/upgrades/20161125174053_convert_variations_to_mapping_in_annotation_storage/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from ftw.shop.interfaces import IVariationConfig
+
+
+class ConvertVariationsToMappingInAnnotationStorage(UpgradeStep):
+    """Convert variations to mapping in annotation storage.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        for item in self.objects({'portal_type': 'ShopItem'},
+                                 'Migrate variations storage'):
+
+            varConf = IVariationConfig(item)
+            item_data = varConf.getVariationDict()
+            varConf.updateVariationConfig(item_data)

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -3,3 +3,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
 
 package-name = ftw.shop
+
+[versions]
+path.py = 8.1.2


### PR DESCRIPTION
This changes the saving of variations to the annotation-storage of a `shopItem` so it will always be stored as a persistent mapping.
When getting the variations from the storage it will be read as a `dict` and when writing the obejcts to the storage again it will be a persistent mapping again.

