### PR TITLE
Convert category rank keys to uid.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 2.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use uid as the key for storing category ranks, not the category object itself.
+  This makes the category ranks serializable and thus publishable for "ftw.publisher".
+  [mbaechtold]
 
 
 2.0.10 (2016-11-28)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.11 (unreleased)
 -------------------
 
+- Drop support for Plone 4.1.
+  [mbaechtold]
+
 - Use uid as the key for storing category ranks, not the category object itself.
   This makes the category ranks serializable and thus publishable for "ftw.publisher".
   [mbaechtold]

--- a/ftw/shop/content/categorizeable.py
+++ b/ftw/shop/content/categorizeable.py
@@ -1,7 +1,7 @@
-from Persistence import PersistentMapping
 from AccessControl import ClassSecurityInfo
-
 from ftw.shop.config import CATEGORY_RELATIONSHIP
+from Persistence import PersistentMapping
+from plone.uuid.interfaces import IUUID
 
 
 class Categorizeable(object):
@@ -17,7 +17,8 @@ class Categorizeable(object):
         """Get the object's rank for the specified category
         """
         if hasattr(self, '_categoryRanks'):
-            return int(self._categoryRanks.get(category, self.defaultRank))
+            category_uuid = IUUID(category)
+            return int(self._categoryRanks.get(category_uuid, self.defaultRank))
         return self.defaultRank
 
 
@@ -29,7 +30,8 @@ class Categorizeable(object):
         if not hasattr(self, '_categoryRanks') \
             or not isinstance(self._categoryRanks, PersistentMapping):
             self._categoryRanks = PersistentMapping()
-        self._categoryRanks[category] = rank
+        category_uuid = IUUID(category)
+        self._categoryRanks[category_uuid] = rank
 
 
     security.declareProtected("Modify portal content", 'addToCategory')

--- a/ftw/shop/upgrades/20161229152823_convert_category_rank_keys_to_uid/upgrade.py
+++ b/ftw/shop/upgrades/20161229152823_convert_category_rank_keys_to_uid/upgrade.py
@@ -1,0 +1,28 @@
+from ftw.shop.content.shopcategory import ShopCategory
+from ftw.upgrade import UpgradeStep
+from plone.uuid.interfaces import IUUID
+
+
+class ConvertCategoryRankKeysToUid(UpgradeStep):
+    """Convert category rank keys to uid.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        objs = self.objects(
+            {
+                'object_provides': [
+                    'ftw.shop.interfaces.IShopCategory',
+                    'ftw.shop.interfaces.IShopItem',
+                ]
+            },
+            message='Converting category rank keys to uid',
+        )
+        for obj in objs:
+            if hasattr(obj, '_categoryRanks'):
+                for category, rank in obj._categoryRanks.iteritems():
+                    if isinstance(category, ShopCategory):
+                        # Only convert the keys the first time the upgrade
+                        # step is run.
+                        obj._categoryRanks[IUUID(category)] = rank
+                        del obj._categoryRanks[category]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='ftw.shop',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Programming Language :: Python',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,8 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-
-package-name = ftw.shop
-
-[versions]
-path.py = 8.1.2


### PR DESCRIPTION
By using a uid as the key for storing category ranks instead of  the category object itself, the category ranks become serializable and thus publishable for "ftw.publisher".

This also drops support for Plone 4.1.