### PR TITLE
Dimensions 2

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,13 @@ Changelog
 2.2.0 (unreleased)
 ------------------
 
+- Enable decimal numbers for dimensions.
+  [lknoepfel]
+
+- Enable different units for dimension entry and price.
+  Eg. input an amount in g and display the price per kg.
+  [lknoepfel]
+
 - Added dimensions to shopitems which can be specified by the user.
   [lknoepfel]
 

--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -47,12 +47,12 @@ jQuery(function ($) {
             };
         }
 
-        var dimensions = $(this).parents('form').find('input[name="dimension:int"]');
+        var dimensions = $(this).parents('form').find('input[name="dimension:float"]');
         dimensions = dimensions.map(
             function() {
                 return $(this).val();
             });
-        itemdata['dimensions'] = dimensions.get().join();
+        itemdata['dimensions'] = dimensions.get().join('|');
 
         $.ajax({
         dataType: "json",

--- a/ftw/shop/browser/templates/checkout/order_review.pt
+++ b/ftw/shop/browser/templates/checkout/order_review.pt
@@ -76,11 +76,11 @@
         </tbody>
         <tfoot>
           <tr tal:condition="python:context.REQUEST['cart_view'].shop_config().vat_enabled">
-              <td><strong i18n:translate="label_vat">VAT</strong></td><td></td><td></td><td></td><td tal:content="context/REQUEST/cart_view/cart_vat"></td>
+              <td><strong i18n:translate="label_vat">VAT</strong></td><td></td><td tal:condition="context/REQUEST/cart_view/cart_has_dimensions"></td><td></td><td></td><td tal:content="context/REQUEST/cart_view/cart_vat"></td>
           </tr>
 
           <tr>
-              <td><strong>Total</strong></td><td></td><td></td><td></td><td tal:content="context/REQUEST/cart_view/cart_total"></td>
+              <td><strong>Total</strong></td><td></td><td tal:condition="context/REQUEST/cart_view/cart_has_dimensions"></td><td></td><td></td><td tal:content="context/REQUEST/cart_view/cart_total"></td>
           </tr>
 
         </tfoot>

--- a/ftw/shop/browser/templates/listing/macros.pt
+++ b/ftw/shop/browser/templates/listing/macros.pt
@@ -5,7 +5,7 @@
             <input
                     type="text"
                     size="3"
-                    tal:attributes="name python: 'dimension:int' if not 'skuCode' in locals() else 'dimension_%s' % skuCode;
+                    tal:attributes="name python: 'dimension:float' if not 'skuCode' in locals() else 'dimension_%s' % skuCode;
                                     value python:'' if not item.get('dimensions') else item['dimensions'][repeat['dimension'].index];" />
         </span>
     </tal:dimensions>

--- a/ftw/shop/browser/templates/listing/one_variation_compact.pt
+++ b/ftw/shop/browser/templates/listing/one_variation_compact.pt
@@ -19,7 +19,7 @@
                                     </label>
                                 </td>
                                 <td class="variationPriceLabel" style="display:none;" tal:condition="python: not varConf.allPricesZero() and item['showPrice']">
-                                    <label><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getDimensionsLabel"> / <span tal:replace="item/item/getDimensionsLabel"></span></span></label>
+                                    <label><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getPriceUnit"> / <span tal:replace="item/item/getPriceUnit"></span></span></label>
                                 </td>
 
                                 <td class="variationSKUCodeLabel" style="display:none;">

--- a/ftw/shop/browser/templates/listing/single_item.pt
+++ b/ftw/shop/browser/templates/listing/single_item.pt
@@ -5,7 +5,7 @@
                     <tr>
                         <th tal:condition="item/skuCode" i18n:translate="label_sku_code">SKU code</th>
                         <th tal:condition="item/unit" i18n:translate="label_unit">Unit</th>
-                        <th tal:condition="item/showPrice"><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getDimensionsLabel"> / <span tal:replace="item/item/getDimensionsLabel"></span></span></th>
+                        <th tal:condition="item/showPrice"><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getPriceUnit"> / <span tal:replace="item/item/getPriceUnit"></span></span></th>
                     </tr>
                     <tr>
                         <td tal:condition="item/skuCode" tal:content="item/skuCode" />

--- a/ftw/shop/browser/templates/listing/two_variations_compact.pt
+++ b/ftw/shop/browser/templates/listing/two_variations_compact.pt
@@ -21,7 +21,7 @@
                                 </td>
 
                                 <td class="variationPriceLabel" style="display:none;" tal:condition="python: not varConf.allPricesZero() and item['showPrice']">
-                                    <label><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getDimensionsLabel"> / <span tal:replace="item/item/getDimensionsLabel"></span></span></label>
+                                    <label><span i18n:translate="label_price">Price</span><span tal:condition="item/item/getPriceUnit"> / <span tal:replace="item/item/getPriceUnit"></span></span></label>
                                 </td>
                                 <td class="variationSKUCodeLabel" style="display:none;">
                                     <label i18n:translate="label_sku_code">SKU code</label>

--- a/ftw/shop/browser/templates/mail/order_confirmation.pt
+++ b/ftw/shop/browser/templates/mail/order_confirmation.pt
@@ -120,6 +120,7 @@ Thank you for your order in our shop on the
    <tr tal:condition="python:shop_config.vat_enabled">
     <td style="border-top: 2px solid black;"><span i18n:translate="label_included_vat">VAT</span></td>
     <td style="border-top: 2px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"><span tal:content="order/vat_amount"/></td>
@@ -128,6 +129,7 @@ Thank you for your order in our shop on the
    <tr>
     <td style="border-top: 3px solid black;"><span i18n:translate="txt_total">Total (incl.VAT)</span></td>
     <td style="border-top: 3px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"><strong tal:content="order/getTotal" /></td>

--- a/ftw/shop/browser/templates/mail/order_notification.pt
+++ b/ftw/shop/browser/templates/mail/order_notification.pt
@@ -122,6 +122,7 @@
    <tr tal:condition="python:shop_config.vat_enabled">
     <td style="border-top: 2px solid black;"><span i18n:translate="label_included_vat">VAT</span></td>
     <td style="border-top: 2px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"><span tal:content="order/vat_amount"/></td>
@@ -130,6 +131,7 @@
    <tr>
     <td style="border-top: 3px solid black;"><span i18n:translate="txt_total">Total (incl.VAT)</span></td>
     <td style="border-top: 3px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 2px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"><strong tal:content="order/getTotal" /></td>

--- a/ftw/shop/browser/templates/mail/supplier_notification.pt
+++ b/ftw/shop/browser/templates/mail/supplier_notification.pt
@@ -112,6 +112,7 @@
    <tr tal:condition="python:shop_config.vat_enabled">
     <td style="border-top: 2px solid black;"><span i18n:translate="label_included_vat">VAT</span></td>
     <td style="border-top: 2px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"></td>
     <td style="border-top: 2px solid black;"><span tal:content="order/vat_amount"/></td>
@@ -120,6 +121,7 @@
    <tr>
     <td style="border-top: 3px solid black;"><span i18n:translate="txt_total">Total (incl.VAT)</span></td>
     <td style="border-top: 3px solid black;"></td>
+    <td tal:condition="has_order_dimensions" style="border-top: 2px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"></td>
     <td style="border-top: 3px solid black;"><strong tal:content="order/getTotal" /></td>

--- a/ftw/shop/content/shopitem.py
+++ b/ftw/shop/content/shopitem.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Definition of the Shop Item content type
 """
 
@@ -30,32 +31,72 @@ from ftw.shop.config import PROJECTNAME
 from ftw.shop import shopMessageFactory as _
 
 
-# Update the SelectableDimensionsVocabulary if you add an item!
 selectable_dimensions = {
     'no_dimensions': {
+        'label': _(u"label_no_dimensions", default=u"---"),
         'dimension_unit': None,
         'dimensions': []
     },
-    'length': {
+    'length_mm_mm': {
+        'label': _(u"label_length", default=u"Length"),
         'dimension_unit': u'mm',
         'dimensions': [_(u"Length (mm)")]
     },
-    'length_width': {
-        'dimension_unit': _(u'mm2'),
+    'length_m_m': {
+        'label': _(u"label_length", default=u"Length"),
+        'dimension_unit': u'm',
+        'dimensions': [_(u"Length (m)")]
+    },
+    'length_width_mm_mm2': {
+        'label': _(u"label_l_w", default=u"Length, Width"),
+        'dimension_unit': u'mm²',
         'dimensions': [
             _(u"Length (mm)"),
             _(u"Width (mm)")]
     },
-    'length_width_thickness': {
-        'dimension_unit': _(u'mm3'),
+    'length_width_mm_m2': {
+        'label': _(u"label_l_w", default=u"Length, Width"),
+        'price_unit': u'm²',
+        'price_to_dimension_modifier': 1000000,
+        'dimension_unit': u'mm²',
+        'dimensions': [
+            _(u"Length (mm)"),
+            _(u"Width (mm)")]
+    },
+    'length_width_thickness_mm_mm3': {
+        'label': _(u"label_l_w_t", default=u"Length, Width, Thickness"),
+        'dimension_unit': u'mm³',
         'dimensions': [
             _(u"Length (mm)"),
             _(u"Width (mm)"),
             _(u"Thickness (mm)")]
     },
-    'weight': {
+    'length_width_thickness_mm_m3': {
+        'label': _(u"label_l_w_t", default=u"Length, Width, Thickness"),
+        'price_unit': u'm³',
+        'price_to_dimension_modifier': 1000000000,
+        'dimension_unit': u'mm³',
+        'dimensions': [
+            _(u"Length (mm)"),
+            _(u"Width (mm)"),
+            _(u"Thickness (mm)")]
+    },
+    'weight_g_g': {
+        'label': _(u'label_weight', default=u"Weight"),
         'dimension_unit': u'g',
         'dimensions': [_(u"Weight (g)")]
+    },
+    'weight_g_kg': {
+        'label': _(u'label_weight', default=u"Weight"),
+        'price_unit': u'kg',
+        'price_to_dimension_modifier': 1000,
+        'dimension_unit': u'g',
+        'dimensions': [_(u"Weight (g)")]
+    },
+    'weight_kg_kg': {
+        'label': _(u'label_weight', default=u"Weight"),
+        'dimension_unit': u'kg',
+        'dimensions': [_(u"Weight (kg)")]
     }
 }
 
@@ -233,7 +274,7 @@ class ShopItem(Categorizeable, ATCTContent):
 
     def getDimensionDict(self):
         dim_key = self.Schema().getField('selectable_dimensions').get(self)
-        if not dim_key:
+        if not dim_key or dim_key not in selectable_dimensions:
             return selectable_dimensions['no_dimensions']
 
         return selectable_dimensions[dim_key]
@@ -245,6 +286,16 @@ class ShopItem(Categorizeable, ATCTContent):
     def getDimensionsLabel(self):
         dimension_dict = self.getDimensionDict()
         return dimension_dict.get('dimension_unit', None)
+
+    def getPriceUnit(self):
+        dimension_dict = self.getDimensionDict()
+        if 'price_unit' in dimension_dict:
+            return dimension_dict['price_unit']
+        return dimension_dict.get('dimension_unit', None)
+
+    def getPriceModifier(self):
+        dimension_dict = self.getDimensionDict()
+        return dimension_dict.get('price_to_dimension_modifier', 1)
 
 
 def add_to_containing_category(context, event):

--- a/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ftw.shop\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: 2015-01-22 09:06+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -77,7 +77,11 @@ msgstr "Warenkorb leeren"
 msgid "Filter"
 msgstr "Anzeigen"
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr "Länge (m)"
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr "Länge (mm)"
 
@@ -107,11 +111,11 @@ msgstr "Shop-Artikel"
 msgid "Supplier"
 msgstr "Lieferant"
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr "Dicke (mm)"
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr "Diese E-Mail Adresse ist ungültig."
 
@@ -143,26 +147,30 @@ msgstr ""
 msgid "Variations"
 msgstr "Variationen"
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr "Gramm (g)"
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr "Gewicht (kg)"
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr "Breite (mm)"
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr "Zurück"
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr "Weiter"
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr "Abschliessen"
 
@@ -173,42 +181,42 @@ msgstr "Löschen"
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr "Beschreibung"
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr "Abmessung"
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr "Preis"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr "Produkt"
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr "Menge"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -238,42 +246,42 @@ msgstr "Titel"
 msgid "categories_title"
 msgstr "Kategorien"
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -283,35 +291,41 @@ msgstr ""
 msgid "desc_vat_rate"
 msgstr ""
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
+#, fuzzy
 msgid "description_dimensions"
 msgstr "Definiert welche Abmessungen am Produkt vom Kunden gewählt werden können. Der Preis wird pro Einheit (mm, mm³, etc.) angebeben."
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
 msgstr "Die Mengeneinheit in der das Produkt gemessen wird."
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
+msgstr "%(label)s (%(dimension)s) - Preis in %(price)s"
 
 #: ./ftw/shop/configure.zcml:52
 msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr "Einzelheiten zu Ihrer Bestellung"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr "Bestellte Artikel"
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr "Details zur Bestellung"
 
@@ -340,15 +354,15 @@ msgstr "Dieses Portlet zeigt den Inhalt des Warenkorbs an"
 msgid "help_always_notify_shop_owner"
 msgstr "Auch dann eine eMail an den Shopbesitzer senden wenn Lieferant(en) benachrichtigt wurde(n)"
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr ""
 
@@ -362,7 +376,7 @@ msgstr ""
 msgid "help_name"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr ""
 
@@ -428,14 +442,14 @@ msgid "label_any_status"
 msgstr "Alle"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr "Artikel-Nr."
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr "Text"
 
@@ -445,7 +459,7 @@ msgid "label_cart"
 msgstr "Artikel"
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr "Warenkorbinhalt"
 
@@ -465,7 +479,7 @@ msgid "label_checkout_group"
 msgstr "Bestellvorgang"
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr "Bestellvorgang"
 
@@ -475,8 +489,7 @@ msgid "label_city"
 msgstr "Ort"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr "Bemerkungen"
 
@@ -506,24 +519,24 @@ msgid "label_customer"
 msgstr "Kunde"
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr "Datum"
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr "Kontaktinformationen"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr "Zahlungsanbieter"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr "Lieferadresse"
 
@@ -535,9 +548,9 @@ msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr "Bemerkungen"
 
@@ -567,8 +580,8 @@ msgstr "Variationen bearbeiten"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-Mail"
 
@@ -588,36 +601,36 @@ msgid "label_from_date"
 msgstr "Von:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr "Bild"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr "MwSt"
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr "Länge (mm)"
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
-msgstr "Länge, Breite (mm²)"
+msgstr "Länge, Breite"
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
-msgstr "Länge, Breite, Dicke (mm³)"
+msgstr "Länge, Breite, Dicke"
 
 #. Default: "Last Name"
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Nachname"
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
+msgstr "Länge"
 
 #. Default: "BCC Address"
 #: ./ftw/shop/interfaces.py:171
@@ -670,7 +683,7 @@ msgid "label_new_value_2"
 msgstr "Neuer Wert 2"
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -690,7 +703,7 @@ msgid "label_order_no"
 msgstr "Bestellnummer"
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr "Bestellungsübersicht"
 
@@ -700,8 +713,8 @@ msgid "label_order_review_step_group"
 msgstr "Bestellungsübersichts-Schritt"
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr "Bestellungs-Status"
 
@@ -711,7 +724,7 @@ msgid "label_order_storage"
 msgstr "Storage-Methode für Bestellungen"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Zahlungsanbieter"
@@ -728,8 +741,8 @@ msgstr "Persönliche Informationen"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Tel."
 
@@ -756,7 +769,7 @@ msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr "Abmessung"
 
@@ -766,7 +779,7 @@ msgid "label_selected_orders"
 msgstr "Ausgewählte Bestellungen"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr "Lieferadresse"
 
@@ -791,7 +804,7 @@ msgid "label_shop_name"
 msgstr "Geben sie den Shop-Namen ein"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Preis anzeigen"
@@ -841,7 +854,7 @@ msgstr "Übersicht"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr "Lieferant"
 
@@ -856,7 +869,7 @@ msgid "label_supplier_email"
 msgstr "E-Mail"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr "Lieferant aus übergeordneter Kategorie"
 
@@ -883,36 +896,36 @@ msgid "label_up_to_shop_setup"
 msgstr "Aufwärts zu Shop-Einrichtung"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr "Abweichende Lieferadresse"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Variations-Attribut 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Werte für Variation 1"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Variations-Attribut 2"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Werte für Variation 2"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr "MwSt"
 
@@ -942,9 +955,9 @@ msgid "label_vat_rates"
 msgstr "MwSt-Sätze"
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
-msgstr "Gramm (g)"
+msgstr "Gewicht"
 
 #. Default: "Zip Code"
 #: ./ftw/shop/interfaces.py:321
@@ -954,26 +967,18 @@ msgstr "Postleitzahl"
 msgid "link_agb"
 msgstr "http://www.4teamwork.ch"
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr "mm²"
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr "mm³"
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr "Der Warenkorb wurde geleert."
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr "Ungültige Mengenangabe. Der Warenkorb wurde nicht aktualisiert."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr "Der Warenkorb wurde aktualisiert."
 
@@ -982,38 +987,39 @@ msgstr "Der Warenkorb wurde aktualisiert."
 msgid "msg_categories_updated"
 msgstr "Kategorien wurden aktualisiert."
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#, fuzzy
 msgid "msg_external_redirect"
 msgstr "Sie werden nun auf eine externe Seite des Zahlungsanbieters weitergeleitet"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr "Ungültige Abmessung."
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr "Der Artikel wurde in den Warenkorb gelegt."
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr "Artikel ist deaktiviert und kann nicht hinzugefügt werden"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr "Fehler"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr "Information"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr "Weiterfahren mit leeren Warenkorb nicht möglich"
 
@@ -1024,7 +1030,7 @@ msgid "msg_not_buyable"
 msgstr "<dt>Nicht kaufbar</dt> <dd>${edit_variations}</dd>"
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 msgid "msg_order_cancelled"
 msgstr "${no_orders} Bestellungen storniert."
 
@@ -1034,7 +1040,7 @@ msgid "msg_shop_initialized"
 msgstr "Shop-Struktur initialisiert"
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr "Status für ${no_orders} Bestellungen wurde geändert."
 
@@ -1083,42 +1089,42 @@ msgid "status_online_pending"
 msgstr "Pendent (Online-Zahlung)"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr "Standard-Kontaktinformationen"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr "Standard-Kontaktinformationen"
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr "Standard-Bestellungsübersicht"
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr "Standard-Bestellungsübersicht"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr "Standard-Zahlungsanbieterauswahl"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr "Standard-Zahlungsanbieterauswahl"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr "Standard Lieferadressen-Schritt"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr "Standard Lieferadressen-Schritt"
 
@@ -1138,67 +1144,67 @@ msgid "title_orders"
 msgstr "Bestellungen"
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr "Adressangaben"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr "Lieferadresse"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact"
 msgstr "Bei Fragen kontaktieren Sie uns bitte: ${phone} E-Mail ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr ""
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr "Ihre Bestellnummer lautet"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr "Verpackung und Versandkosten sind nicht enthalten und werden individuell verrechnet."
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr "Guten Tag, ein Kunde hat in Ihrem Webshop eine Bestellung aufgegeben:"
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr "Bestellnummer"
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr "Danke für Ihre Bestellung am ${date}"
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr "Sehr geehrte/r"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 msgid "txt_total"
 msgstr "Total (inkl. MwSt)"
 

--- a/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Enny Rodriguez <administrador@femto.com.ve>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,7 +78,11 @@ msgstr "Limpiar carrito de compra"
 msgid "Filter"
 msgstr "Filtro"
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr ""
 
@@ -108,11 +112,11 @@ msgstr "Artículo"
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr ""
 
@@ -144,26 +148,30 @@ msgstr ""
 msgid "Variations"
 msgstr "Variaciones de producto"
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr ""
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr "Anterior"
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr "Siguiente"
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr "Finalizar"
 
@@ -174,42 +182,42 @@ msgstr "Eliminar"
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr "Descripción"
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr ""
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr "Precio"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr "Producto"
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr "Cantidad"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -239,42 +247,42 @@ msgstr "Título"
 msgid "categories_title"
 msgstr "Categorías"
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr "Descuento"
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr "Mostrar precio"
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr "Código"
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr "Proveedor"
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr "Atributo"
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr "Valor"
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr "Atributo"
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr "Valor"
@@ -284,14 +292,19 @@ msgstr "Valor"
 msgid "desc_vat_rate"
 msgstr "Por favor, seleccione el tipo de impuesto al valor agregado por este producto."
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
+msgstr ""
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
 msgstr ""
 
 #: ./ftw/shop/configure.zcml:52
@@ -299,20 +312,20 @@ msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr "Detalles de su orden"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr "Productos pedidos"
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr "Detalles de la orden"
 
@@ -341,15 +354,15 @@ msgstr "Este porlet visualiza el contenido del carrito de compra"
 msgid "help_always_notify_shop_owner"
 msgstr "También Enviar email al propietario si el proveedor(es) se han notificado"
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr "Información de contacto"
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr "Proceso de pago"
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr "Información de envío"
 
@@ -363,7 +376,7 @@ msgstr "Sujeto para el envío del correo con la información de la orden de comp
 msgid "help_name"
 msgstr "Nombre del proveedor"
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr "Revision de la orden"
 
@@ -429,14 +442,14 @@ msgid "label_any_status"
 msgstr "Cualquier estado"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr "Número de artículo"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr "Texto del cuerpo"
 
@@ -446,7 +459,7 @@ msgid "label_cart"
 msgstr "Carrito"
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr "Contenido del carrito"
 
@@ -466,7 +479,7 @@ msgid "label_checkout_group"
 msgstr "Pedido"
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr "Pedido"
 
@@ -476,8 +489,7 @@ msgid "label_city"
 msgstr "Ciudad"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr "Comentarios"
 
@@ -507,24 +519,24 @@ msgid "label_customer"
 msgstr "Comprador"
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr "Fecha"
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr "Información de contacto"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr "Procesador de pago"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr "Dirección de envío"
 
@@ -536,9 +548,9 @@ msgid "label_description"
 msgstr "Descripción"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr "Comentarios"
 
@@ -568,8 +580,8 @@ msgstr "Editar variaciones"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "Correo electrónico"
 
@@ -589,29 +601,24 @@ msgid "label_from_date"
 msgstr "De:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr "Imagen"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr "I.V.A"
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr ""
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
 msgstr ""
 
@@ -619,6 +626,11 @@ msgstr ""
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Apellido"
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
+msgstr ""
 
 #. Default: "BCC Address"
 #: ./ftw/shop/interfaces.py:171
@@ -671,7 +683,7 @@ msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -691,7 +703,7 @@ msgid "label_order_no"
 msgstr "Orden número."
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr "Revision de orden"
 
@@ -701,8 +713,8 @@ msgid "label_order_review_step_group"
 msgstr "Paso Revision de la orden"
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr "Estado de la orden"
 
@@ -712,7 +724,7 @@ msgid "label_order_storage"
 msgstr "Método de almacenamiento de la orden"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Método de pago"
@@ -729,8 +741,8 @@ msgstr "Información de pago"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Teléfono"
 
@@ -757,7 +769,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -767,7 +779,7 @@ msgid "label_selected_orders"
 msgstr "Orden seleccionada"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr "Dirección de envío"
 
@@ -792,7 +804,7 @@ msgid "label_shop_name"
 msgstr "Ingrese el nombre de la tienda"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Mostrar precio"
@@ -842,7 +854,7 @@ msgstr "Resumen"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr "Proveedor"
 
@@ -857,7 +869,7 @@ msgid "label_supplier_email"
 msgstr "Dirección"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr "Proveedor de la categoría padre"
 
@@ -884,36 +896,36 @@ msgid "label_up_to_shop_setup"
 msgstr "Volver a configuración de la tienda"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr "Diferente a la dirección de la factura"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Atributo variación 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Variación 1 valores"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Variación 2 atributos"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Variación 2 valores"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr "I.V.A"
 
@@ -943,7 +955,7 @@ msgid "label_vat_rates"
 msgstr "I.V.A Tasas"
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
 msgstr ""
 
@@ -955,26 +967,18 @@ msgstr "Código postal"
 msgid "link_agb"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr ""
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr ""
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr "Se ha limpiado el carrito"
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr "Valores especificados no válidos. Carrito no actualizado."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr "Carrito actualizado"
 
@@ -983,38 +987,39 @@ msgstr "Carrito actualizado"
 msgid "msg_categories_updated"
 msgstr "Categorías actualizadas"
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#, fuzzy
 msgid "msg_external_redirect"
 msgstr "serás redirigido a un sitio externo"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr "Producto añadido al carrito"
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr "Producto deshabilitado. No puede ser añadido"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr "Error"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr "Información"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr "No se puede continuar con el carrito vacío"
 
@@ -1025,7 +1030,7 @@ msgid "msg_not_buyable"
 msgstr "<dt>No disponible</dt> <dd>${edit_variations}</dd>"
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 msgid "msg_order_cancelled"
 msgstr "${no_orders} Ordenes canceladas."
 
@@ -1035,7 +1040,7 @@ msgid "msg_shop_initialized"
 msgstr "Estructura de la tienda inicializada"
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr "Estado cambiado para ${no_orders} ordenes."
 
@@ -1084,42 +1089,42 @@ msgid "status_online_pending"
 msgstr "Pendiente (Pago en línea)"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr "Información de contacto por defecto"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr "Información de contacto por defecto"
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr "Paso Revisión de orden por defecto"
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr "Paso Revisión de orden por defecto"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr "Procesador de pago por defecto"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr "Procesador de pago por defecto"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr "Dirección de envío por defecto"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr "Dirección de envío por defecto"
 
@@ -1139,67 +1144,67 @@ msgid "title_orders"
 msgstr "Ordenes"
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr "Información personal"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr "Dirección de envío"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact"
 msgstr "Para consultas por favor póngase en contacto con nosotros  ${phone} E-Mail ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr "Teléfono"
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr "Tu número de orden es"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr "Costos de envío y embalaje no están incluidos y se cobrarán por separado."
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr "Hola, <br /> un cliente ha realizado un pedido en su tienda electrónica:"
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr "Número de orden"
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr "Gracias por su pedido en nuestra tienda el día $ {fecha}"
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr "Estimado"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 msgid "txt_total"
 msgstr "Total + I.V.A"
 

--- a/ftw/shop/locales/eu/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/eu/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ftw.shop\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: 2015-01-22 09:08+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -77,7 +77,11 @@ msgstr "Saskia hustu"
 msgid "Filter"
 msgstr "Filtroa"
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr ""
 
@@ -107,11 +111,11 @@ msgstr "Erosgaia"
 msgid "Supplier"
 msgstr "Hornitzailea"
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr "E-posta helbide hau ez da zuzena."
 
@@ -143,26 +147,30 @@ msgstr ""
 msgid "Variations"
 msgstr "Aldakiak"
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr ""
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr "Atzera"
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr "Hurrengoa"
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr "Bukatu"
 
@@ -173,42 +181,42 @@ msgstr "Ezabatu"
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr "Deskribapena"
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr ""
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr "Prezioa"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr "Produktua"
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr "Kopurua"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr "Guztira"
 
@@ -238,42 +246,42 @@ msgstr "Izena"
 msgid "categories_title"
 msgstr "Kategoriak"
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -283,14 +291,19 @@ msgstr ""
 msgid "desc_vat_rate"
 msgstr "Aukeratu elementu honi dagokion BEZa"
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
+msgstr ""
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
 msgstr ""
 
 #: ./ftw/shop/configure.zcml:52
@@ -298,20 +311,20 @@ msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr "Zure eskariaren xehetasunak"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr "Eskatutako produktuak"
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr "Eskariaren xehetasunak"
 
@@ -340,15 +353,15 @@ msgstr "Portlet honek erosketa saskiaren edukiak erakusten ditu."
 msgid "help_always_notify_shop_owner"
 msgstr "Jabeari ere mezua bidali hornitzaileei ere bidali bazaie."
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr ""
 
@@ -362,7 +375,7 @@ msgstr "Eskaera e-posten gaia"
 msgid "help_name"
 msgstr "Hornitzailearen izena"
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr ""
 
@@ -428,14 +441,14 @@ msgid "label_any_status"
 msgstr "Edozein egoera"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr "Erosgai-kodea (SKU)"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr "Testua"
 
@@ -445,7 +458,7 @@ msgid "label_cart"
 msgstr "Saskia"
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr "Saskiaren edukia"
 
@@ -465,7 +478,7 @@ msgid "label_checkout_group"
 msgstr "Ordaindu"
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr "Ordaindu"
 
@@ -475,8 +488,7 @@ msgid "label_city"
 msgstr "Hiria"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr "Komentarioak"
 
@@ -506,24 +518,24 @@ msgid "label_customer"
 msgstr "Bezeroa"
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr "Data"
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr "Kontakturako informazioa"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr "Ordainketa prozesatzailea"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr "Bidalketa helbidea"
 
@@ -535,9 +547,9 @@ msgid "label_description"
 msgstr "Deskribapena"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr "Komentarioak"
 
@@ -567,8 +579,8 @@ msgstr "Aldakiak aldatu"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-posta"
 
@@ -588,29 +600,24 @@ msgid "label_from_date"
 msgstr "Noiztik:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr "Irudia"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr "BEZ"
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr ""
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
 msgstr ""
 
@@ -618,6 +625,11 @@ msgstr ""
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Abizena"
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
+msgstr ""
 
 #. Default: "BCC Address"
 #: ./ftw/shop/interfaces.py:171
@@ -670,7 +682,7 @@ msgid "label_new_value_2"
 msgstr "Balio berria 2"
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -690,7 +702,7 @@ msgid "label_order_no"
 msgstr "Eskari-zenbakia"
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr "Eskaria gainbegiratu"
 
@@ -700,8 +712,8 @@ msgid "label_order_review_step_group"
 msgstr "Eskaria gainbegiratzeko pausua"
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr "Eskariaren egoera"
 
@@ -711,7 +723,7 @@ msgid "label_order_storage"
 msgstr "Eskariak gordetzeko modua"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Ordainketa prozesatzailea"
@@ -728,8 +740,8 @@ msgstr "Informazio pertsonala"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Telefonoa"
 
@@ -756,7 +768,7 @@ msgid "label_save"
 msgstr "Gorde"
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -766,7 +778,7 @@ msgid "label_selected_orders"
 msgstr "Aukeratutako eskariak"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr "Bidalketa-helbidea"
 
@@ -791,7 +803,7 @@ msgid "label_shop_name"
 msgstr "Dendaren izena"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Prezioa erakutsi"
@@ -841,7 +853,7 @@ msgstr "Laburpena"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr "Hornitzailea"
 
@@ -856,7 +868,7 @@ msgid "label_supplier_email"
 msgstr "E-posta"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr "Kategoria gurasoko hornitzailea"
 
@@ -883,36 +895,36 @@ msgid "label_up_to_shop_setup"
 msgstr "Dendaren ezarpenetara joan"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr "Fakturazio helbidearen ezberdina erabili"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "1. aldakiaren atributu-izena"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "1. aldakiaren balioa"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "2. aldakiaren atributu-izena"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "2. aldakiaren balioa"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr "BEZ"
 
@@ -942,7 +954,7 @@ msgid "label_vat_rates"
 msgstr "BEZ ehunekoak"
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
 msgstr ""
 
@@ -954,26 +966,18 @@ msgstr "Posta-kodea"
 msgid "link_agb"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr ""
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr ""
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr "Saskia hustu egin da."
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr "Balioak ez dira zuzenak. Saskia ez da eguneratu."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr "Saskia eguneratu egin da."
 
@@ -982,38 +986,39 @@ msgstr "Saskia eguneratu egin da."
 msgid "msg_categories_updated"
 msgstr "Kategoriak eguneratu egin dira."
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#, fuzzy
 msgid "msg_external_redirect"
 msgstr "Orain, kanpoko webgune batera bideratuko zaitugu ordainketa gauzatzeko."
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr "Erosgaia saskian sartu duzu."
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr "Erosgaia desaktibatuta dago eta ezin da gehitu."
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr "Errorea"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr "Informazioa"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr "Ezin da jarraitu saskia hutsik badago."
 
@@ -1024,7 +1029,7 @@ msgid "msg_not_buyable"
 msgstr "<dt>Ezin da erosi</dt> <dd>${edit_variations}</dd>"
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 msgid "msg_order_cancelled"
 msgstr "${no_orders} eskaera bertan behera utzi dira."
 
@@ -1034,7 +1039,7 @@ msgid "msg_shop_initialized"
 msgstr "Dendaren egitura hasieratuta."
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr "${no_orders} eskariren egoera aldatu egin da."
 
@@ -1083,42 +1088,42 @@ msgid "status_online_pending"
 msgstr "Ordainketaren zain"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr "Defektuzko kontaktu-informazioa"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr "Defektuzko kontaktu-informazioa"
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr "Eskaeraren errebisio pausua"
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr "Eskaeraren errebisio pausuaren taldea"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr "Defektuzko ordainketa prozesatzailearen aukera"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr "Defektuzko ordainketa prozesatzailearen aukera"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr "Defektuzko bidalketa-helbidea"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr "Defektuzko bidalketa-helbidea"
 
@@ -1138,67 +1143,67 @@ msgid "title_orders"
 msgstr "Eskariak"
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr "Informazioa"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr "Bidalketa-helbidea"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact"
 msgstr "Eskaerak edo galderak badituzu, jarri kontaktuan gurekin. Telefonoa ${phone} E-posta ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr "Telefonoa"
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr "Zure eskaera zenbakia hau da"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr "Bidalketa gastuak ez daude sartuta eta aparte kobratuko dira."
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr "Kaixo, <br/> bezero batek zuren dendan eskari bat egin du:"
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr "Eskari zenbakia"
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr "Eskerrik asko gure dendan ${date}-n eskari bat egitearren"
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr "Kaixo "
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 msgid "txt_total"
 msgstr "Guztira (BEZ barne)"
 

--- a/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -77,7 +77,11 @@ msgstr "Vider votre panier"
 msgid "Filter"
 msgstr "Filtre"
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr ""
 
@@ -109,11 +113,11 @@ msgstr "Article boutique"
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr ""
 
@@ -145,26 +149,30 @@ msgstr ""
 msgid "Variations"
 msgstr "Variations"
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr ""
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr "Retour"
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr "Continue"
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr "Finir"
 
@@ -175,42 +183,42 @@ msgstr "Effacer"
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr "Description"
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr ""
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr "Prix"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr "Produit"
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr "Quantité"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -240,42 +248,42 @@ msgstr "Title"
 msgid "categories_title"
 msgstr "Catégories"
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -285,14 +293,19 @@ msgstr ""
 msgid "desc_vat_rate"
 msgstr ""
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
+msgstr ""
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
 msgstr ""
 
 #: ./ftw/shop/configure.zcml:52
@@ -300,20 +313,20 @@ msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr "Détails de votre commande"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr "Articles commandés"
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr "Details d'ordres'"
 
@@ -342,15 +355,15 @@ msgstr ""
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr ""
 
@@ -364,7 +377,7 @@ msgstr ""
 msgid "help_name"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr ""
 
@@ -430,14 +443,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr "Numméro de commande"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr ""
 
@@ -447,7 +460,7 @@ msgid "label_cart"
 msgstr "Panier"
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr "Contenu panier"
 
@@ -467,7 +480,7 @@ msgid "label_checkout_group"
 msgstr ""
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr "Procédure de commande"
 
@@ -477,8 +490,7 @@ msgid "label_city"
 msgstr "Lieu"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr "Remarques"
 
@@ -508,24 +520,24 @@ msgid "label_customer"
 msgstr "Client"
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr "Date"
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr "Information de contacts"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr "Fournisseur de paiement"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr "Adresse de livraison"
 
@@ -537,9 +549,9 @@ msgid "label_description"
 msgstr "Description"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr "Remarques"
 
@@ -570,8 +582,8 @@ msgstr "Modifier les variations"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-mail"
 
@@ -591,29 +603,24 @@ msgid "label_from_date"
 msgstr "De:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr ""
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr ""
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
 msgstr ""
 
@@ -621,6 +628,11 @@ msgstr ""
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
 msgstr "Nom"
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
+msgstr ""
 
 #. Default: "BCC Address"
 #: ./ftw/shop/interfaces.py:171
@@ -673,7 +685,7 @@ msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -693,7 +705,7 @@ msgid "label_order_no"
 msgstr ""
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr "Aperçu de commandes"
 
@@ -703,8 +715,8 @@ msgid "label_order_review_step_group"
 msgstr "Étape aperçu de commandes"
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr "État de la commande"
 
@@ -714,7 +726,7 @@ msgid "label_order_storage"
 msgstr "Méthode d'enregistrer pour les commandes"
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr "Fournisseur de paiement"
@@ -731,8 +743,8 @@ msgstr "Information personelle"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Tél."
 
@@ -759,7 +771,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -769,7 +781,7 @@ msgid "label_selected_orders"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr "Adresse de livraison"
 
@@ -794,7 +806,7 @@ msgid "label_shop_name"
 msgstr "Entree le nom boutique"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -845,7 +857,7 @@ msgstr "Aperçu"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr ""
 
@@ -860,7 +872,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -887,36 +899,36 @@ msgid "label_up_to_shop_setup"
 msgstr "Jusqu'à l'installation boutique"
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr "Adresse differe livraison"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Attribute variation 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Value attribute variation 1"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Attribtue variation 2"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Value attribute variation 2"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr ""
 
@@ -946,7 +958,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
 msgstr ""
 
@@ -958,26 +970,18 @@ msgstr "Code postale"
 msgid "link_agb"
 msgstr "http://www.amnesty.ch/fr/contacts/impressum/questions-legales/conditions-d-achat-en-ligne/"
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr ""
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr ""
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr "Le panier a été vidé"
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr "Nombre non valable. Le panier n'a pas été actualisé."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr "Le panier a été actualisé."
 
@@ -986,38 +990,39 @@ msgstr "Le panier a été actualisé."
 msgid "msg_categories_updated"
 msgstr "Categories actualiser"
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#, fuzzy
 msgid "msg_external_redirect"
 msgstr "Vous serez redirigé vers un site externe du fournisseur de paiement"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr "L'article a été mis dans le panier"
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr "Article disabled. Pas possible d'ajouter"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr "Erreur"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr "Information"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr "Commande n'est pas possible avec un panier vide"
 
@@ -1028,7 +1033,7 @@ msgid "msg_not_buyable"
 msgstr "<dt>Pas pour acheter</dt> <dd>${edit_variations}</dd>"
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 #, fuzzy
 msgid "msg_order_cancelled"
 msgstr "Commande annulée"
@@ -1039,7 +1044,7 @@ msgid "msg_shop_initialized"
 msgstr "Structure de boutique initialisée"
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr ""
 
@@ -1088,42 +1093,42 @@ msgid "status_online_pending"
 msgstr ""
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr "Coordonnées standard"
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr "Coordonnées standard"
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr "aperçu de commande standard"
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr "aperçu de commande standard"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr "Sélection standard fournisseur de paiement"
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr "Sélection standard fournisseur de paiement"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr "Etape Adresse de livraison standard"
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr "Etape Adresse de livraison standard"
 
@@ -1143,68 +1148,68 @@ msgid "title_orders"
 msgstr "Commandes"
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr "Mon adresse"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr "Adresse de livraison"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 #, fuzzy
 msgid "txt_contact"
 msgstr "Pour demandes, veuillez vous adresser à: Tél 031 307 22 22, E-mail <a href=\"mailto:webmaster@amnesty.ch\">webmaster@amnesty.ch</a> "
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr ""
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr "Votre commande"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr "Les frais d'emballage et d'envoi ne sont pas compris et seront facturés en sus."
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr "Bonjour, un client a envoyé une commande dans votre boutique"
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr "Numéro de commande"
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr "Merci pour votre commande sur www.amnesty.ch du ${date}"
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr "Chère, cher"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 #, fuzzy
 msgid "txt_total"
 msgstr "Total"

--- a/ftw/shop/locales/ftw.shop.pot
+++ b/ftw/shop/locales/ftw.shop.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -75,7 +75,11 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr ""
 
@@ -105,11 +109,11 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr ""
 
@@ -141,26 +145,30 @@ msgstr ""
 msgid "Variations"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr ""
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr ""
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr ""
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr ""
 
@@ -171,42 +179,42 @@ msgstr ""
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr ""
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr ""
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr ""
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr ""
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr ""
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr ""
 
@@ -236,42 +244,42 @@ msgstr ""
 msgid "categories_title"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -281,14 +289,19 @@ msgstr ""
 msgid "desc_vat_rate"
 msgstr ""
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
+msgstr ""
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
 msgstr ""
 
 #: ./ftw/shop/configure.zcml:52
@@ -296,20 +309,20 @@ msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr ""
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr ""
 
@@ -338,15 +351,15 @@ msgstr ""
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr ""
 
@@ -360,7 +373,7 @@ msgstr ""
 msgid "help_name"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr ""
 
@@ -426,14 +439,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr ""
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr ""
 
@@ -443,7 +456,7 @@ msgid "label_cart"
 msgstr ""
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr ""
 
@@ -463,7 +476,7 @@ msgid "label_checkout_group"
 msgstr ""
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr ""
 
@@ -473,8 +486,7 @@ msgid "label_city"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr ""
 
@@ -504,24 +516,24 @@ msgid "label_customer"
 msgstr ""
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr ""
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr ""
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr ""
 
@@ -533,9 +545,9 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr ""
 
@@ -565,8 +577,8 @@ msgstr ""
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr ""
 
@@ -586,35 +598,35 @@ msgid "label_from_date"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr ""
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr ""
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
 msgstr ""
 
 #. Default: "Last Name"
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
+msgstr ""
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
 msgstr ""
 
 #. Default: "BCC Address"
@@ -668,7 +680,7 @@ msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -688,7 +700,7 @@ msgid "label_order_no"
 msgstr ""
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr ""
 
@@ -698,8 +710,8 @@ msgid "label_order_review_step_group"
 msgstr ""
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr ""
 
@@ -709,7 +721,7 @@ msgid "label_order_storage"
 msgstr ""
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr ""
@@ -726,8 +738,8 @@ msgstr ""
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr ""
 
@@ -754,7 +766,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -764,7 +776,7 @@ msgid "label_selected_orders"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr ""
 
@@ -789,7 +801,7 @@ msgid "label_shop_name"
 msgstr ""
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -839,7 +851,7 @@ msgstr ""
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr ""
 
@@ -854,7 +866,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -881,36 +893,36 @@ msgid "label_up_to_shop_setup"
 msgstr ""
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr ""
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr ""
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr ""
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr ""
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr ""
 
@@ -940,7 +952,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
 msgstr ""
 
@@ -952,26 +964,18 @@ msgstr ""
 msgid "link_agb"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr ""
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr ""
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr ""
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr ""
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr ""
 
@@ -980,38 +984,38 @@ msgstr ""
 msgid "msg_categories_updated"
 msgstr ""
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
 msgid "msg_external_redirect"
 msgstr ""
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr ""
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr ""
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr ""
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr ""
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr ""
 
@@ -1022,7 +1026,7 @@ msgid "msg_not_buyable"
 msgstr ""
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 msgid "msg_order_cancelled"
 msgstr ""
 
@@ -1032,7 +1036,7 @@ msgid "msg_shop_initialized"
 msgstr ""
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr ""
 
@@ -1081,42 +1085,42 @@ msgid "status_online_pending"
 msgstr ""
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr ""
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr ""
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr ""
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr ""
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr ""
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr ""
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr ""
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr ""
 
@@ -1136,67 +1140,67 @@ msgid "title_orders"
 msgstr ""
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr ""
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact"
 msgstr ""
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr ""
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr ""
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr ""
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr ""
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr ""
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr ""
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr ""
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 msgid "txt_total"
 msgstr ""
 

--- a/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-04-03 07:26+0000\n"
+"POT-Creation-Date: 2017-05-09 07:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -77,7 +77,11 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:50
+msgid "Length (m)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:44
 msgid "Length (mm)"
 msgstr ""
 
@@ -109,11 +113,11 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:54
+#: ./ftw/shop/content/shopitem.py:76
 msgid "Thickness (mm)"
 msgstr ""
 
-#: ./ftw/shop/interfaces.py:342
+#: ./ftw/shop/interfaces.py:347
 msgid "This email address is invalid."
 msgstr ""
 
@@ -145,26 +149,30 @@ msgstr ""
 msgid "Variations"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:92
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:47
+#: ./ftw/shop/content/shopitem.py:105
+msgid "Weight (kg)"
+msgstr ""
+
+#: ./ftw/shop/content/shopitem.py:58
 msgid "Width (mm)"
 msgstr ""
 
 #. Default: "Back"
-#: ./ftw/shop/browser/checkout.py:329
+#: ./ftw/shop/browser/checkout.py:332
 msgid "btn_back"
 msgstr ""
 
 #. Default: "Next"
-#: ./ftw/shop/browser/checkout.py:351
+#: ./ftw/shop/browser/checkout.py:354
 msgid "btn_continue"
 msgstr ""
 
 #. Default: "Finish"
-#: ./ftw/shop/browser/checkout.py:373
+#: ./ftw/shop/browser/checkout.py:376
 msgid "btn_finish"
 msgstr ""
 
@@ -175,42 +183,42 @@ msgstr ""
 
 #. Default: "Description"
 #: ./ftw/shop/browser/templates/cart_edit.pt:28
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:55
 msgid "cart_header_description"
 msgstr ""
 
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:56
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_dimensions"
 msgstr ""
 
 #. Default: "Price"
 #: ./ftw/shop/browser/templates/cart_edit.pt:31
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:61
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:58
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_price"
 msgstr ""
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:98
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:54
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
 msgid "cart_header_product"
 msgstr ""
 
 #. Default: "Quantity"
 #: ./ftw/shop/browser/templates/cart_edit.pt:30
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:60
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:57
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_quantity"
 msgstr ""
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:62
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_total"
 msgstr ""
 
@@ -240,42 +248,42 @@ msgstr ""
 msgid "categories_title"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:103
+#: ./ftw/shop/content/shopitem.py:150
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:114
+#: ./ftw/shop/content/shopitem.py:161
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:124
+#: ./ftw/shop/content/shopitem.py:171
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:209
+#: ./ftw/shop/content/shopitem.py:257
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:162
+#: ./ftw/shop/content/shopitem.py:210
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:173
+#: ./ftw/shop/content/shopitem.py:221
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:185
+#: ./ftw/shop/content/shopitem.py:233
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:196
+#: ./ftw/shop/content/shopitem.py:244
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -285,14 +293,19 @@ msgstr ""
 msgid "desc_vat_rate"
 msgstr ""
 
-#. Default: "Specifies which dimensions of the product can be chosen by the user."
-#: ./ftw/shop/content/shopitem.py:148
+#. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
+#: ./ftw/shop/content/shopitem.py:195
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:133
+#: ./ftw/shop/content/shopitem.py:180
 msgid "description_unit"
+msgstr ""
+
+#. Default: "%(label)s (%(dimension)s) - price in %(price)s"
+#: ./ftw/shop/vocabularies.py:201
+msgid "dimensions_format"
 msgstr ""
 
 #: ./ftw/shop/configure.zcml:52
@@ -300,20 +313,20 @@ msgid "ftw.shop"
 msgstr ""
 
 #. Default: "Details of your order"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:23
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:24
 msgid "header_orderdetails"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:92
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:94
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:90
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
 msgid "header_ordereditems"
 msgstr ""
 
 #. Default: "Details of the order"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:18
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:18
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:19
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:19
 msgid "header_shopowner_orderdetails"
 msgstr ""
 
@@ -342,15 +355,15 @@ msgstr ""
 msgid "help_always_notify_shop_owner"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:69
+#: ./ftw/shop/browser/checkout.py:71
 msgid "help_default_contact_info_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:202
+#: ./ftw/shop/browser/checkout.py:204
 msgid "help_default_payment_processor_choice_step"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:148
+#: ./ftw/shop/browser/checkout.py:150
 msgid "help_default_shipping_address_step"
 msgstr ""
 
@@ -364,7 +377,7 @@ msgstr ""
 msgid "help_name"
 msgstr ""
 
-#: ./ftw/shop/browser/checkout.py:236
+#: ./ftw/shop/browser/checkout.py:238
 msgid "help_order_review_step"
 msgstr ""
 
@@ -430,14 +443,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:97
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:99
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:94
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
 msgid "label_article_no"
 msgstr ""
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:139
 msgid "label_body_text"
 msgstr ""
 
@@ -447,7 +460,7 @@ msgid "label_cart"
 msgstr ""
 
 #. Default: "Cart Contents"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:49
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:46
 msgid "label_cart_contents"
 msgstr ""
 
@@ -467,7 +480,7 @@ msgid "label_checkout_group"
 msgstr ""
 
 #. Default: "Checkout"
-#: ./ftw/shop/browser/checkout.py:253
+#: ./ftw/shop/browser/checkout.py:256
 msgid "label_checkout_wizard"
 msgstr ""
 
@@ -477,8 +490,7 @@ msgid "label_city"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:26
-#: ./ftw/shop/interfaces.py:333
+#: ./ftw/shop/interfaces.py:338
 msgid "label_comments"
 msgstr ""
 
@@ -508,24 +520,24 @@ msgid "label_customer"
 msgstr ""
 
 #. Default: "Date"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:23
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:23
 #: ./ftw/shop/browser/templates/order_manager.pt:97
 msgid "label_date"
 msgstr ""
 
 #. Default: "Contact Information"
-#: ./ftw/shop/browser/checkout.py:65
+#: ./ftw/shop/browser/checkout.py:67
 msgid "label_default_contact_info_step"
 msgstr ""
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/checkout.py:198
+#: ./ftw/shop/browser/checkout.py:200
 msgid "label_default_payment_processor_choice_step"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/checkout.py:144
+#: ./ftw/shop/browser/checkout.py:146
 msgid "label_default_shipping_address_step"
 msgstr ""
 
@@ -537,9 +549,9 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:64
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:65
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:62
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
 msgid "label_details_comments"
 msgstr ""
 
@@ -569,8 +581,8 @@ msgstr ""
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:54
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr ""
 
@@ -590,35 +602,35 @@ msgid "label_from_date"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:69
+#: ./ftw/shop/content/shopitem.py:116
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:119
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:121
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:112
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
 msgid "label_included_vat"
 msgstr ""
 
-#. Default: "Length"
-#: ./ftw/shop/vocabularies.py:196
-msgid "label_l"
-msgstr ""
-
 #. Default: "Length, Width"
-#: ./ftw/shop/vocabularies.py:197
+#: ./ftw/shop/content/shopitem.py:53
 msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/vocabularies.py:198
+#: ./ftw/shop/content/shopitem.py:70
 msgid "label_l_w_t"
 msgstr ""
 
 #. Default: "Last Name"
 #: ./ftw/shop/interfaces.py:297
 msgid "label_lastname"
+msgstr ""
+
+#. Default: "Length"
+#: ./ftw/shop/content/shopitem.py:41
+msgid "label_length"
 msgstr ""
 
 #. Default: "BCC Address"
@@ -672,7 +684,7 @@ msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/vocabularies.py:195
+#: ./ftw/shop/content/shopitem.py:36
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -692,7 +704,7 @@ msgid "label_order_no"
 msgstr ""
 
 #. Default: "Order Review"
-#: ./ftw/shop/browser/checkout.py:233
+#: ./ftw/shop/browser/checkout.py:235
 msgid "label_order_review_step"
 msgstr ""
 
@@ -702,8 +714,8 @@ msgid "label_order_review_step_group"
 msgstr ""
 
 #. Default: "Order Status"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:25
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:24
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:26
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:25
 msgid "label_order_status"
 msgstr ""
 
@@ -713,7 +725,7 @@ msgid "label_order_storage"
 msgstr ""
 
 #. Default: "Payment Processor"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:91
 #: ./ftw/shop/interfaces.py:128
 msgid "label_payment_processor"
 msgstr ""
@@ -730,8 +742,8 @@ msgstr ""
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:58
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr ""
 
@@ -758,7 +770,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:146
+#: ./ftw/shop/content/shopitem.py:193
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -768,7 +780,7 @@ msgid "label_selected_orders"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:33
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:30
 msgid "label_shipping_address"
 msgstr ""
 
@@ -793,7 +805,7 @@ msgid "label_shop_name"
 msgstr ""
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:113
+#: ./ftw/shop/content/shopitem.py:160
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -843,7 +855,7 @@ msgstr ""
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:256
 msgid "label_supplier"
 msgstr ""
 
@@ -858,7 +870,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:184
+#: ./ftw/shop/vocabularies.py:186
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -885,36 +897,36 @@ msgid "label_up_to_shop_setup"
 msgstr ""
 
 #. Default: "Different from invoice address"
-#: ./ftw/shop/interfaces.py:355
+#: ./ftw/shop/interfaces.py:360
 msgid "label_used"
 msgstr ""
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:208
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr ""
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:219
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr ""
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:183
+#: ./ftw/shop/content/shopitem.py:231
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr ""
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:194
+#: ./ftw/shop/content/shopitem.py:242
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:82
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:79
 msgid "label_vat"
 msgstr ""
 
@@ -944,7 +956,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/vocabularies.py:200
+#: ./ftw/shop/content/shopitem.py:89
 msgid "label_weight"
 msgstr ""
 
@@ -956,26 +968,18 @@ msgstr ""
 msgid "link_agb"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
-msgid "mm2"
-msgstr ""
-
-#: ./ftw/shop/content/shopitem.py:50
-msgid "mm3"
-msgstr ""
-
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:323
+#: ./ftw/shop/browser/cart.py:331
 msgid "msg_cart_emptied"
 msgstr ""
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:345
+#: ./ftw/shop/browser/cart.py:353
 msgid "msg_cart_invalidvalue"
 msgstr ""
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:308
+#: ./ftw/shop/browser/cart.py:316
 msgid "msg_cart_updated"
 msgstr ""
 
@@ -984,38 +988,38 @@ msgstr ""
 msgid "msg_categories_updated"
 msgstr ""
 
-#. Default: "You will now be redirected to an external site."
-#: ./ftw/shop/browser/templates/checkout/order_review.pt:98
+#. Default: "<p>&nbsp;</p>You will now be redirected to an external site."
+#: ./ftw/shop/browser/templates/checkout/order_review.pt:94
 msgid "msg_external_redirect"
 msgstr ""
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:425
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:276
+#: ./ftw/shop/browser/cart.py:284
 msgid "msg_item_added"
 msgstr ""
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:279
+#: ./ftw/shop/browser/cart.py:287
 msgid "msg_item_disabled"
 msgstr ""
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:412
+#: ./ftw/shop/browser/cart.py:420
 msgid "msg_label_error"
 msgstr ""
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:409
+#: ./ftw/shop/browser/cart.py:417
 msgid "msg_label_info"
 msgstr ""
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:498
+#: ./ftw/shop/browser/cart.py:511
 msgid "msg_no_cart"
 msgstr ""
 
@@ -1026,7 +1030,7 @@ msgid "msg_not_buyable"
 msgstr ""
 
 #. Default: "${no_orders} orders cancelled."
-#: ./ftw/shop/browser/ordermanager.py:272
+#: ./ftw/shop/browser/ordermanager.py:273
 msgid "msg_order_cancelled"
 msgstr ""
 
@@ -1036,7 +1040,7 @@ msgid "msg_shop_initialized"
 msgstr ""
 
 #. Default: "Changed status for ${no_orders} orders."
-#: ./ftw/shop/browser/ordermanager.py:298
+#: ./ftw/shop/browser/ordermanager.py:299
 msgid "msg_status_changed"
 msgstr ""
 
@@ -1085,42 +1089,42 @@ msgid "status_online_pending"
 msgstr ""
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:67
+#: ./ftw/shop/browser/checkout.py:69
 msgid "title_default_contact_info_step"
 msgstr ""
 
 #. Default: "Default Contact Information"
-#: ./ftw/shop/browser/checkout.py:136
+#: ./ftw/shop/browser/checkout.py:138
 msgid "title_default_contact_info_step_group"
 msgstr ""
 
 #. Default: "Default Order Review Step"
-#: ./ftw/shop/browser/checkout.py:234
+#: ./ftw/shop/browser/checkout.py:236
 msgid "title_default_order_review_step"
 msgstr ""
 
 #. Default: "Default Order Review Step Group"
-#: ./ftw/shop/browser/checkout.py:247
+#: ./ftw/shop/browser/checkout.py:250
 msgid "title_default_order_review_step_group"
 msgstr ""
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:200
+#: ./ftw/shop/browser/checkout.py:202
 msgid "title_default_payment_processor_step"
 msgstr ""
 
 #. Default: "Default Payment Processor Choice"
-#: ./ftw/shop/browser/checkout.py:211
+#: ./ftw/shop/browser/checkout.py:213
 msgid "title_default_payment_processor_step_group"
 msgstr ""
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:146
+#: ./ftw/shop/browser/checkout.py:148
 msgid "title_default_shipping_address_step"
 msgstr ""
 
 #. Default: "Default Shipping Address"
-#: ./ftw/shop/browser/checkout.py:190
+#: ./ftw/shop/browser/checkout.py:192
 msgid "title_default_shipping_address_step_group"
 msgstr ""
 
@@ -1140,67 +1144,67 @@ msgid "title_orders"
 msgstr ""
 
 #. Default: "Personal Information"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:30
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:31
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:29
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:31
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:32
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:30
 msgid "title_personal_information"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:69
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:70
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:72
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
 msgid "title_shipping_address"
 msgstr ""
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:148
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact"
 msgstr ""
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
 msgid "txt_contact_phone"
 msgstr ""
 
 #. Default: "Your order number is"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:26
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:27
 msgid "txt_ordernumber"
 msgstr ""
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:140
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:141
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
 msgid "txt_shipping"
 msgstr ""
 
 #. Default: "Hello, <br /> a customer has placed an order in your Webshop:"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:14
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:14
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:15
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:15
 msgid "txt_shopowner_greeting"
 msgstr ""
 
 #. Default: "Order number"
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:21
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:20
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:22
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:21
 msgid "txt_shopowner_ordernumber"
 msgstr ""
 
 #. Default: "Thank you for your order in our shop on the ${date}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:20
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:21
 msgid "txt_thankyou"
 msgstr ""
 
 #. Default: "Dear"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:14
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:15
 msgid "txt_title"
 msgstr ""
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:127
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:129
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:120
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
 msgid "txt_total"
 msgstr ""
 

--- a/ftw/shop/tests/base.py
+++ b/ftw/shop/tests/base.py
@@ -186,7 +186,7 @@ class FtwShopTestCase(ptc.PloneTestCase):
         self.movie.getField('showPrice').set(self.movie, True)
         self.movie.getField('title').set(self.movie, "A Movie")
         self.movie.getField('description').set(self.movie, "A Shop Item with no variations")
-        self.movie.getField('selectable_dimensions').set(self.movie, 'length_width')
+        self.movie.getField('selectable_dimensions').set(self.movie, 'length_width_mm_mm2')
 
         # Fire ObjectInitializedEvent to add item to containing category
         event = ObjectInitializedEvent(self.movie, self.portal.REQUEST)

--- a/ftw/shop/tests/test_dimensions.py
+++ b/ftw/shop/tests/test_dimensions.py
@@ -1,14 +1,15 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.shop.browser.cart import validate_dimensions
+from ftw.shop.content.shopitem import selectable_dimensions
 from ftw.shop.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 
 
-class TestUnitField(FunctionalTestCase):
+class TestDimensions(FunctionalTestCase):
 
     def setUp(self):
-        super(TestUnitField, self).setUp()
+        super(TestDimensions, self).setUp()
         self.grant('Manager')
 
         self.folder = create(Builder('folder'))
@@ -17,7 +18,7 @@ class TestUnitField(FunctionalTestCase):
                                .titled('Raindrops')
                                .having(price='2.00',
                                        showPrice=True,
-                                       selectable_dimensions='length_width')
+                                       selectable_dimensions='length_width_mm_mm2')
                                .within(self.category))
 
     @browsing
@@ -26,24 +27,24 @@ class TestUnitField(FunctionalTestCase):
 
         self.assertEquals(
             2,
-            len(browser.css('.dimensions-selection input[name="dimension:int"]')))
+            len(browser.css('.dimensions-selection input[name="dimension:float"]')))
 
     @browsing
     def test_dimension_add_and_edit(self, browser):
         browser.login().visit(self.shopitem)
 
-        dim = browser.css('.dimensions-selection input[name="dimension:int"]')
-        dim[0].value = '2'
+        dim = browser.css('.dimensions-selection input[name="dimension:float"]')
+        dim[0].value = '2.5'
         dim[1].value = '3'
         browser.fill({'quantity:int': '1'}).submit()
 
         browser.open(self.portal, view='cart_edit')
 
         dim = browser.css('.dimensions-selection input')
-        self.assertEquals('2', dim[0].value)
+        self.assertEquals('2.5', dim[0].value)
         self.assertEquals('3', dim[1].value)
         # check if price is correctly multiplied
-        self.assertEquals('12.00', browser.css('form > div b span').first.text)
+        self.assertEquals('15.00', browser.css('form > div b span').first.text)
 
         dim[1].value = '4'
 
@@ -51,7 +52,7 @@ class TestUnitField(FunctionalTestCase):
 
         dim = browser.css('.dimensions-selection input')
         self.assertEquals('4', dim[1].value)
-        self.assertEquals('16.00', browser.css('form > div b span').first.text)
+        self.assertEquals('20.00', browser.css('form > div b span').first.text)
 
     def test_dimensions_validation(self):
         self.assertTrue(validate_dimensions([], []))
@@ -67,9 +68,43 @@ class TestUnitField(FunctionalTestCase):
         self.assertFalse(
             validate_dimensions([], None),
             'Both parameter have to be specified.')
-        self.assertFalse(
-            validate_dimensions(['2.2'], [u'Length (mm)']),
-            'Float numbers are not allowed. The base unit cannot be split.')
+        self.assertTrue(validate_dimensions(['2.2'], [u'Length (mm)']))
         self.assertFalse(
             validate_dimensions([-1], [u'Length (mm)']),
             'Negative dimensions are not allowed.')
+
+    def test_dimensions_format(self):
+        # this tests check if all selectable dimension configs are valid
+        for key, config in selectable_dimensions.iteritems():
+            self.assertIn('label', config)
+            self.assertIn('dimensions', config)
+            self.assertIn('dimension_unit', config)
+            self.assertTrue(isinstance(config['dimensions'], list))
+
+            if key == 'no_dimensions':
+                continue
+
+            if 'price_unit' in config:
+                self.assertIn('price_to_dimension_modifier', config)
+
+    @browsing
+    def test_different_price_unit(self, browser):
+        """ This tests creates a shopitem which takes g as input and displays
+            the price in kg. The final price has to convert between those units.
+        """
+        self.priceitem = create(Builder('shop item')
+                                .titled('Farbe')
+                                .having(price='200.00',
+                                        showPrice=True,
+                                        selectable_dimensions='weight_g_kg')
+                                .within(self.category))
+
+        browser.login().visit(self.priceitem)
+
+        dim = browser.css('.dimensions-selection input[name="dimension:float"]')
+        dim[0].value = '150'
+        browser.fill({'quantity:int': '1'}).submit()
+
+        browser.open(self.portal, view='cart_edit')
+
+        self.assertEquals('30.00', browser.css('form > div b span').first.text)


### PR DESCRIPTION
 *  Enabled decimal numbers for dimensions.
Straight forward. This is required enable inputs in e.g. kg or m where the user wants to order 2.25m of this fabric.
I moved most computation to `Decimal` because of the common float imprecision and the price was already in `Decimal`.

 *  Enable different units for dimension entry and price.
This is required to make sensible price tags. E.g. the users orders a piece of wood 200x300x800mm. The price should be in m3 not mm3. This conversion from dimensions to price unit was implemented (mm3->m3).

