### PR TITLE
Different dimensions in cart

### DIFF
--- a/ftw/shop/browser/cart.py
+++ b/ftw/shop/browser/cart.py
@@ -193,7 +193,14 @@ class ShoppingCartAdapter(object):
             item['variation_code'] if 'variation_code' in item else '',
             dimensions)
         if key != new_key:
-            cart_items[new_key] = cart_items[key]
+            if new_key in cart_items:
+                # i want a cookie if this ever happens
+                self.update_item(new_key,
+                                 int(quantity)+cart_items[new_key]['quantity'],
+                                 dimensions)
+            else:
+                cart_items[new_key] = cart_items[key]
+
             del cart_items[key]
 
         session[CART_KEY] = cart_items

--- a/ftw/shop/browser/cart.py
+++ b/ftw/shop/browser/cart.py
@@ -378,12 +378,11 @@ class ShoppingCartAdapter(object):
 
         # delete items with quantity 0
         del_items = []
-        # XXX - these are not skuCodes but item keys - rename!
-        for skuCode in self.get_items().keys():
+        for item_key in self.get_items().keys():
             try:
-                qty = int(float(self.request.get('quantity_%s' % skuCode)))
+                qty = int(float(self.request.get('quantity_%s' % item_key)))
                 if qty <= 0:
-                    del_items.append(skuCode)
+                    del_items.append(item_key)
             except (ValueError, TypeError):
                 ptool.addPortalMessage(
                     _(u'msg_cart_invalidvalue',
@@ -393,14 +392,14 @@ class ShoppingCartAdapter(object):
                                            context.absolute_url())
                 self.request.response.redirect(referer)
                 return
-        for skuCode in del_items:
-            self._remove_item(skuCode)
+        for item_key in del_items:
+            self._remove_item(item_key)
 
         # now update quantities and dimensions
         for item_key, item in self.get_items().items():
-            quantity = float(self.request.get('quantity_%s' % skuCode))
+            quantity = float(self.request.get('quantity_%s' % item_key))
 
-            dimensions = self.request.get('dimension_%s' % skuCode, [])
+            dimensions = self.request.get('dimension_%s' % item_key, [])
             if not isinstance(dimensions, list):
                 dimensions = [dimensions]
 
@@ -413,6 +412,8 @@ class ShoppingCartAdapter(object):
                                            context.absolute_url())
                 self.request.response.redirect(referer)
                 return
+
+            dimensions = map(Decimal, dimensions)
 
             # check that dimension changes do not collide
             item = self.get_items()[item_key]
@@ -429,8 +430,6 @@ class ShoppingCartAdapter(object):
                                            context.absolute_url())
                 self.request.response.redirect(referer)
                 return
-
-            dimensions = map(Decimal, dimensions)
 
             self.update_item(item_key, quantity, dimensions)
 

--- a/ftw/shop/content/variations.py
+++ b/ftw/shop/content/variations.py
@@ -46,15 +46,6 @@ class VariationConfig(object):
         """
         return self.context.UID()
 
-    def key(self, varcode1=None, varcode2=None):
-        """A unique id for each item and variation combination.
-        """
-        if varcode1 is None:
-            return self.context.UID()
-        if varcode2 is None:
-            return '%s-%s' % (self.context.UID(), varcode1)
-        return '%s-%s-%s' % (self.context.UID(), varcode1, varcode2)
-
     def variation_code(self, var1choice=None, var2choice=None):
         """
         """

--- a/ftw/shop/tests/test_cart.py
+++ b/ftw/shop/tests/test_cart.py
@@ -180,9 +180,13 @@ class TestCart(FtwShopTestCase):
         self.portal.REQUEST['quantity_%s==3-3' % self.movie.UID()] = 1
         cart.cart_update()
 
+        ptool = getToolByName(self.portal, 'plone_utils')
+        last_msg = ptool.showPortalMessages()[-1].message
+        self.assertEquals(last_msg, u'Invalid Values specified. Cart not updated.')
+
         cart_items = cart.cart_items()
-        self.assertEquals(1, len(cart_items))
-        self.assertEquals(3, cart_items[self.movie.UID()+'==3-3']['quantity'])
+        self.assertEquals(2, len(cart_items))
+        self.assertEquals(1, cart_items[self.movie.UID()+'==3-3']['quantity'])
 
     def test_cart_remove(self):
         ptool = getToolByName(self.portal, 'plone_utils')

--- a/ftw/shop/tests/test_cart.py
+++ b/ftw/shop/tests/test_cart.py
@@ -21,18 +21,18 @@ class TestCart(FtwShopTestCase):
         cart.addtocart("12345", quantity=2, dimension=[Decimal(1), Decimal(2)])
         cart_items = cart.cart_items()
         self.assertEquals(len(cart_items), 1)
-        item_uid = self.movie.UID() + '==1-2'
-        self.assertEquals(cart_items[item_uid]['price'], '7.15')
-        self.assertEquals(cart_items[item_uid]['total'], '28.60')
-        self.assertEquals(cart_items[item_uid]['skucode'], '12345')
-        self.assertEquals(cart_items[item_uid]['quantity'], 2)
-        self.assertEquals(cart_items[item_uid]['title'], 'A Movie')
-        self.assertEquals(cart_items[item_uid]['description'], 'A Shop Item with no variations')
+        item_key = self.movie.UID() + '==1-2'
+        self.assertEquals(cart_items[item_key]['price'], '7.15')
+        self.assertEquals(cart_items[item_key]['total'], '28.60')
+        self.assertEquals(cart_items[item_key]['skucode'], '12345')
+        self.assertEquals(cart_items[item_key]['quantity'], 2)
+        self.assertEquals(cart_items[item_key]['title'], 'A Movie')
+        self.assertEquals(cart_items[item_key]['description'], 'A Shop Item with no variations')
         self.assertEquals(cart.cart_total(), '28.60')
 
         # Add an item type that's already in the cart
         cart.addtocart("12345", quantity=1, dimension=[Decimal(1), Decimal(2)])
-        self.assertEquals(cart.cart_items()[item_uid]['quantity'], 3)
+        self.assertEquals(cart.cart_items()[item_key]['quantity'], 3)
         self.assertEquals(cart.cart_total(), '42.90')
 
 

--- a/ftw/shop/tests/test_cart.py
+++ b/ftw/shop/tests/test_cart.py
@@ -21,7 +21,7 @@ class TestCart(FtwShopTestCase):
         cart.addtocart("12345", quantity=2, dimension=[Decimal(1), Decimal(2)])
         cart_items = cart.cart_items()
         self.assertEquals(len(cart_items), 1)
-        item_uid = self.movie.UID()
+        item_uid = self.movie.UID() + '==1-2'
         self.assertEquals(cart_items[item_uid]['price'], '7.15')
         self.assertEquals(cart_items[item_uid]['total'], '28.60')
         self.assertEquals(cart_items[item_uid]['skucode'], '12345')
@@ -41,20 +41,20 @@ class TestCart(FtwShopTestCase):
         cart.addtocart(var1choice='Paperback', quantity=3)
         cart_items = cart.cart_items()
         self.assertEquals(len(cart_items), 2)
-        item_uid = "%s-Paperback" % self.book.UID()
+        item_key = "%s=var-Paperback=" % self.book.UID()
 
-        self.assertEquals(cart_items[item_uid]['price'], '2.00')
-        self.assertEquals(cart_items[item_uid]['total'], '6.00')
-        self.assertEquals(cart_items[item_uid]['skucode'], 'b22')
-        self.assertEquals(cart_items[item_uid]['quantity'], 3)
-        self.assertEquals(cart_items[item_uid]['title'], 'Professional Plone Development - None')
-        self.assertEquals(cart_items[item_uid]['description'], 'A Shop Item with one variation')
+        self.assertEquals(cart_items[item_key]['price'], '2.00')
+        self.assertEquals(cart_items[item_key]['total'], '6.00')
+        self.assertEquals(cart_items[item_key]['skucode'], 'b22')
+        self.assertEquals(cart_items[item_key]['quantity'], 3)
+        self.assertEquals(cart_items[item_key]['title'], 'Professional Plone Development - None')
+        self.assertEquals(cart_items[item_key]['description'], 'A Shop Item with one variation')
 
         self.assertEquals(cart.cart_total(), '48.90')
 
         # Add an item type with variations that's already in the cart
         cart.addtocart(var1choice='Paperback', quantity=1)
-        self.assertEquals(cart.cart_items()[item_uid]['quantity'], 4)
+        self.assertEquals(cart.cart_items()[item_key]['quantity'], 4)
         self.assertEquals(cart.cart_total(), '50.90')
 
 
@@ -63,13 +63,13 @@ class TestCart(FtwShopTestCase):
         cart.addtocart(var1choice='Green', var2choice='M', quantity=4)
         cart_items = cart.cart_items()
         self.assertEquals(len(cart_items), 3)
-        item_uid = "%s-Green-M" % self.tshirt.UID()
-        self.assertEquals(cart_items[item_uid]['price'], '5.00')
-        self.assertEquals(cart_items[item_uid]['total'], '20.00')
-        self.assertEquals(cart_items[item_uid]['skucode'], '55')
-        self.assertEquals(cart_items[item_uid]['quantity'], 4)
-        self.assertEquals(cart_items[item_uid]['title'], 'A T-Shirt - None')
-        self.assertEquals(cart_items[item_uid]['description'], 'A Shop Item with two variations')
+        item_key = "%s=var-Green-M=" % self.tshirt.UID()
+        self.assertEquals(cart_items[item_key]['price'], '5.00')
+        self.assertEquals(cart_items[item_key]['total'], '20.00')
+        self.assertEquals(cart_items[item_key]['skucode'], '55')
+        self.assertEquals(cart_items[item_key]['quantity'], 4)
+        self.assertEquals(cart_items[item_key]['title'], 'A T-Shirt - None')
+        self.assertEquals(cart_items[item_key]['description'], 'A Shop Item with two variations')
 
         self.assertEquals(cart.cart_total(), '70.90')
         cart.cart_delete()
@@ -93,18 +93,20 @@ class TestCart(FtwShopTestCase):
         cart = getMultiAdapter((self.movie, self.portal.REQUEST), name='cart_view')
         cart_item_count = len(cart.cart_items())
         cart.addtocart(skuCode='12345', dimension=[Decimal(1), Decimal(2)])
+        movie_key = self.movie.UID()+'==1-2'
         self.assertEquals(len(cart.cart_items()), cart_item_count + 1)
-        self.assertTrue(self.movie.UID() in cart.cart_items())
-        cart.cart._remove_item(self.movie.UID())
+        self.assertTrue(movie_key in cart.cart_items())
+        cart.cart._remove_item(movie_key)
         self.assertEquals(len(cart.cart_items()), cart_item_count)
-        self.assertTrue(self.movie.UID() not in cart.cart_items())
+        self.assertTrue(movie_key not in cart.cart_items())
 
     def test_update_item(self):
         cart = getMultiAdapter((self.movie, self.portal.REQUEST), name='cart_view')
         cart.addtocart(skuCode='12345', quantity=1, dimension=[Decimal(1), Decimal(2)])
-        cart.update_item(self.movie.UID(), 2, [1, 2])
-        self.assertEquals(cart.cart_items()[self.movie.UID()]['quantity'], 2)
-        self.assertEquals(cart.cart_items()[self.movie.UID()]['total'], '28.60')
+        movie_key = self.movie.UID()+'==1-2'
+        cart.update_item(movie_key, 2, [1, 2])
+        self.assertEquals(cart.cart_items()[movie_key]['quantity'], 2)
+        self.assertEquals(cart.cart_items()[movie_key]['total'], '28.60')
 
     def test_cart_update(self):
         ptool = getToolByName(self.portal, 'plone_utils')
@@ -120,11 +122,11 @@ class TestCart(FtwShopTestCase):
         self.assertEquals(len(cart.cart_items()), 2)
 
         # Modify quantities
-        self.portal.REQUEST['quantity_%s' % self.movie.UID()] = 2
-        self.portal.REQUEST['dimension_%s' % self.movie.UID()] = [1, 2]
-        self.portal.REQUEST['quantity_%s-Hardcover' % self.book.UID()] = 0
+        self.portal.REQUEST['quantity_%s==1-2' % self.movie.UID()] = 2
+        self.portal.REQUEST['dimension_%s==1-2' % self.movie.UID()] = [1, 2]
+        self.portal.REQUEST['quantity_%s=var-Hardcover=' % self.book.UID()] = 0
         cart.cart_update()
-        self.assertEquals(cart.cart_items()[self.movie.UID()]['quantity'], 2)
+        self.assertEquals(cart.cart_items()[self.movie.UID()+'==1-2']['quantity'], 2)
         self.assertTrue('b11' not in cart.cart_items())
         last_msg = ptool.showPortalMessages()[-1].message
         self.assertEquals(last_msg, u'Cart updated.')
@@ -135,7 +137,7 @@ class TestCart(FtwShopTestCase):
         cart.addtocart('12345', dimension=[Decimal(1), Decimal(2)])
 
         # Remove the item we just added
-        item_key = self.movie.UID()
+        item_key = self.movie.UID() + '==1-2'
         # XXX - this is not an skuCode but an item key - rename!
         self.portal.REQUEST['skuCode'] = item_key
         cart.cart_remove()


### PR DESCRIPTION
Extranet Ticket: https://extranet.4teamwork.ch/support/paedagogisches-zentrum-pz.bs/tracker/5

This PR adds the ability to add multiple instances of the same article/variation with different dimensions to the cart.

To achieve this we have to change the way the cart item identifier is generated.
Previously it was the item uid with optional variation values attached.
Now it also includes possible dimensions. Since the dimensions can be changed in the cart view, the key has to be updated accordingly.

It does not change anything visually (except some error messages).

An upgrade step is not necessary because carts are cleared on instance reboot anyways. 