### PR TITLE
Sort items in cart by date added.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-2.3.4 (unreleased)
+3.0.0 (unreleased)
 ------------------
+
+- Drop plone 4.2 support (including python 2.6). [lknoepfel]
 
 - Sort items in cart by date added. [lknoepfel]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Sort items in cart by date added. [lknoepfel]
 
 
 2.3.3 (2017-12-11)

--- a/ftw/shop/browser/cart.py
+++ b/ftw/shop/browser/cart.py
@@ -1,8 +1,9 @@
 from Acquisition import aq_inner, aq_parent
+from collections import OrderedDict
 from decimal import Decimal
-from decimal import ROUND_UP
 from decimal import getcontext
 from decimal import InvalidOperation
+from decimal import ROUND_UP
 from ftw.shop import shopMessageFactory as _
 from ftw.shop.config import CART_KEY
 from ftw.shop.config import SESSION_ADDRESS_KEY, ONACCOUNT_KEY
@@ -70,7 +71,7 @@ class ShoppingCartAdapter(object):
         if not browser_id:
             return {}
         session = self.request.SESSION
-        items = session.get(CART_KEY, {})
+        items = session.get(CART_KEY, OrderedDict())
         return items
 
     def get_vat(self):
@@ -171,7 +172,7 @@ class ShoppingCartAdapter(object):
         """Update the quantity or dimensions of an item.
         """
         session = self.request.SESSION
-        cart_items = session.get(CART_KEY, {})
+        cart_items = session.get(CART_KEY, OrderedDict())
 
         if key not in cart_items:
             return
@@ -207,7 +208,7 @@ class ShoppingCartAdapter(object):
 
         # get current items in cart
         session = self.request.SESSION
-        cart_items = session.get(CART_KEY, {})
+        cart_items = session.get(CART_KEY, OrderedDict())
         variation_code = varConf.variation_code(var1choice, var2choice)
 
         # We got no skuCode, so look it up by variation key
@@ -333,7 +334,7 @@ class ShoppingCartAdapter(object):
         """Remove the item with the given key from the cart.
         """
         session = self.request.SESSION
-        cart_items = session.get(CART_KEY, {})
+        cart_items = session.get(CART_KEY, OrderedDict())
 
         if key in cart_items:
             del cart_items[key]
@@ -360,7 +361,7 @@ class ShoppingCartAdapter(object):
         """Remove all items from cart.
         """
         session = self.request.SESSION
-        session[CART_KEY] = {}
+        session[CART_KEY] = OrderedDict()
 
         context = aq_inner(self.context)
         ptool = getToolByName(context, 'plone_utils')

--- a/ftw/shop/tests/test_cart.py
+++ b/ftw/shop/tests/test_cart.py
@@ -153,6 +153,19 @@ class TestCart(FtwShopTestCase):
         last_msg = ptool.showPortalMessages()[-1].message
         self.assertEquals(last_msg, u'Cart updated.')
 
+    def test_cart_item_order(self):
+        # Previously the order of the items was random. This test failed about
+        # half the times it was run. The OrderedDict change fixed it.
+        ptool = getToolByName(self.portal, 'plone_utils')
+        cart = getMultiAdapter((self.book, self.portal.REQUEST), name='cart_view')
+        cart.addtocart(skuCode='b11', var1choice='Hardcover', quantity=2)
+        cart = getMultiAdapter((self.movie, self.portal.REQUEST), name='cart_view')
+        cart.addtocart(skuCode='12345', quantity=1, dimension=[Decimal(1), Decimal(2)])
+        cart.cart_update()
+        self.assertEquals(
+            ['b11', '12345'],
+            [item['skucode'] for item in cart.cart_items().values()])
+
     def test_changing_dimensions_updates_key(self):
         # Add an item with dimensions
         cart = getMultiAdapter((self.movie, self.portal.REQUEST), name='cart_view')

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(name='ftw.shop',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/test-plone-4.2.x.cfg
+++ b/test-plone-4.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-
-package-name = ftw.shop


### PR DESCRIPTION
Replace `dict` where the items were stored in with an `OrderedDict`. The `OrderedDict` keeps the order in which the items are inserted, which is in our case the date added. Modification to the value like a cart edit won't change the order.