### PR TITLE
Calculate and display price per item.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,10 +4,11 @@ Changelog
 3.0.0 (unreleased)
 ------------------
 
+- Calculate and display price per item. [lknoepfel]
+
 - Drop plone 4.2 support (including python 2.6). [lknoepfel]
 
 - Sort items in cart by date added. [lknoepfel]
-
 
 2.3.3 (2017-12-11)
 ------------------

--- a/ftw/shop/browser/resources/shop.js
+++ b/ftw/shop/browser/resources/shop.js
@@ -149,7 +149,7 @@ jQuery(function ($) {
         varSkuCode = varDicts[uid][varcode]['skuCode'];
         varDescription = varDicts[uid][varcode]['description'];
 
-        varSelectTable.find("td.variationPrice").text("CHF " + varPrice);
+        varSelectTable.find("td.variationPrice").html("CHF <span class='price'>" + varPrice + "</span>");
         varSelectTable.find("td.variationSKUCode").text(varSkuCode);
         $(this).parents(".variation-toplevel-group").find("span.variationDescription").text(varDescription);
         $(this).parents(".variation-toplevel-group").find("span.variationDescription").show();

--- a/ftw/shop/browser/resources/shop_price_calculation.js
+++ b/ftw/shop/browser/resources/shop_price_calculation.js
@@ -1,6 +1,6 @@
 // Calculate price per item
-$(document).on('input', ".dimensions-selection input[name^='dimension']", function() {
-    var context = $(this).closest('form, tr');
+function calculatePrice() {
+    var context = $(this).closest('.shopItem, .cartListing tr');
     var dimensions = $("input[name^='dimension']", context).map(function() {
         var number = parseFloat($(this).val());
         // it's not possible to check for NaN with indexOf (NaN != NaN). so convert it to false
@@ -12,7 +12,15 @@ $(document).on('input', ".dimensions-selection input[name^='dimension']", functi
     if (dimensions.indexOf(false) === -1) {
         var volume = dimensions.reduce(function(a, b) {return a*b;});
         var itemData = $('.dimensions-selection', context).data();
-        var pricePerItem = itemData.price / itemData.priceToDimensionModifier * volume;
+
+        if (itemData.hasOwnProperty('price')) {
+            var price = itemData.price;
+        } else {
+            // the price is unknown at render time if the item has variations
+            var price = parseFloat($('.price', context).text());
+        }
+
+        var pricePerItem = price / itemData.priceToDimensionModifier * volume;
 
         // round up
         pricePerItem = Math.ceil(pricePerItem * 100) / 100;
@@ -20,4 +28,7 @@ $(document).on('input', ".dimensions-selection input[name^='dimension']", functi
     }
 
     $('.item-price', context).text(formatted_price);
-});
+}
+
+$(document).on('input', ".dimensions-selection input[name^='dimension']", calculatePrice);
+$(document).on('change', ".variationSelection select", calculatePrice);

--- a/ftw/shop/browser/resources/shop_price_calculation.js
+++ b/ftw/shop/browser/resources/shop_price_calculation.js
@@ -1,0 +1,23 @@
+// Calculate price per item
+$(document).on('input', ".dimensions-selection input[name^='dimension']", function() {
+    var context = $(this).closest('form, tr');
+    var dimensions = $("input[name^='dimension']", context).map(function() {
+        var number = parseFloat($(this).val());
+        // it's not possible to check for NaN with indexOf (NaN != NaN). so convert it to false
+        return (!isNaN(number)) ? number : false;
+    }).toArray();
+
+    var formatted_price = "-";
+
+    if (dimensions.indexOf(false) === -1) {
+        var volume = dimensions.reduce(function(a, b) {return a*b;});
+        var itemData = $('.dimensions-selection', context).data();
+        var pricePerItem = itemData.price / itemData.priceToDimensionModifier * volume;
+
+        // round up
+        pricePerItem = Math.ceil(pricePerItem * 100) / 100;
+        formatted_price = pricePerItem.toLocaleString('de-CH', {minimumFractionDigits: 2});
+    }
+
+    $('.item-price', context).text(formatted_price);
+});

--- a/ftw/shop/browser/templates/cart_edit.pt
+++ b/ftw/shop/browser/templates/cart_edit.pt
@@ -49,7 +49,7 @@
                       <td tal:condition="cview/cart_has_dimensions"><span metal:use-macro="item/@@shopitem_macros/dimensions"></span></td>
                       <td tal:condition="cview/show_prices">
                           <span tal:condition="item/show_price">
-                              CHF <span tal:content="python: item['price_per_item'] if len(item['dimensions']) > 0 else item['price']">123.00</span>
+                              CHF <span class="item-price" tal:content="python: item['price_per_item'] if len(item['dimensions']) > 0 else item['price']">123.00</span>
                           </span>
                       </td>
                       <td><input type="text" size="5"

--- a/ftw/shop/browser/templates/cart_edit.pt
+++ b/ftw/shop/browser/templates/cart_edit.pt
@@ -27,8 +27,8 @@
                     <th i18n:translate="cart_header_product">Product</th>
                     <th i18n:translate="cart_header_description">Description</th>
                     <th tal:condition="cview/cart_has_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+                    <th i18n:translate="cart_header_price" tal:condition="cview/show_prices">Price per item</th>
                     <th i18n:translate="cart_header_quantity">Quantity</th>
-                    <th i18n:translate="cart_header_price" tal:condition="cview/show_prices">Price</th>
                     <th tal:condition="cview/show_prices" i18n:translate="cart_header_total">Total</th>
                     <th i18n:translate="cart_header_delete">Delete</th>
                   </tr>
@@ -47,16 +47,16 @@
                       </td>
                       <td tal:content="item/description"></td>
                       <td tal:condition="cview/cart_has_dimensions"><span metal:use-macro="item/@@shopitem_macros/dimensions"></span></td>
+                      <td tal:condition="cview/show_prices">
+                          <span tal:condition="item/show_price">
+                              CHF <span tal:content="python: item['price_per_item'] if len(item['dimensions']) > 0 else item['price']">123.00</span>
+                          </span>
+                      </td>
                       <td><input type="text" size="5"
                                  tal:attributes="value item/quantity;
                                                  name string:quantity_${skuCode}" /></td>
 
                       <!-- TODO: hackish - better make sure prices are stored normalized in varConf -->
-                      <td tal:condition="cview/show_prices">
-                          CHF <span tal:condition="python:item['show_price']"
-                                tal:content="python:item['price'] in ('0.00', '0.0') and ' ' or item['price']"
-                                />
-                      </td>
                       <td tal:condition="cview/show_prices">
                           CHF <span tal:condition="python:item['show_price']"
                                 tal:content="python:item['total'] in ('0.00', '0.0') and ' ' or item['total']"

--- a/ftw/shop/browser/templates/checkout/order_review.pt
+++ b/ftw/shop/browser/templates/checkout/order_review.pt
@@ -54,8 +54,8 @@
             <th i18n:translate="cart_header_product">Product</th>
             <th i18n:translate="cart_header_description">Description</th>
             <th tal:condition="context/REQUEST/cart_view/cart_has_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+            <th i18n:translate="cart_header_price">Price per item</th>
             <th i18n:translate="cart_header_quantity">Quantity</th>
-            <th i18n:translate="cart_header_price">Price</th>
             <th i18n:translate="cart_header_total">Total</th>
           </tr>
         </thead>
@@ -67,8 +67,8 @@
               <td tal:condition="context/REQUEST/cart_view/cart_has_dimensions">
                   <span metal:use-macro="context/@@shopitem_macros/dimensions_display"></span>
               </td>
+              <td tal:content="item/price_per_item"></td>
               <td tal:content="item/quantity"></td>
-              <td tal:content="item/price"></td>
               <td tal:content="item/total"></td>
             </tr>
           </metal:block>

--- a/ftw/shop/browser/templates/listing/macros.pt
+++ b/ftw/shop/browser/templates/listing/macros.pt
@@ -1,4 +1,6 @@
-<span metal:define-macro="dimensions" class="dimensions-selection">
+<span metal:define-macro="dimensions" class="dimensions-selection"
+        tal:attributes="data-price item/price;
+                        data-price-to-dimension-modifier python: item['item'].getPriceModifier() if 'item' in item else item['price_modifier'] ;">
     <tal:dimensions tal:repeat="dimension item/selectable_dimensions">
         <span>
             <label tal:content="dimension"></label>
@@ -9,6 +11,15 @@
                                     value python:'' if not item.get('dimensions') else item['dimensions'][repeat['dimension'].index];" />
         </span>
     </tal:dimensions>
+
+    <tal:priceperitem tal:condition="python: not item.get('dimensions') and len(item.get('selectable_dimensions', [])) > 0">
+        <tal:comment replace="nothing">With this condition the price tag is added to add-views of shop items.</tal:comment>
+        <label i18n:translate="cart_header_price"></label>
+        <span>
+            CHF
+            <span class="item-price">-</span>
+        </span>
+    </tal:priceperitem>
 </span>
 
 <span metal:define-macro="dimensions_display" class="dimensions-display">
@@ -19,8 +30,4 @@
             <span tal:condition="python: not hasattr(item, 'dimensions')" tal:content="python:item['dimensions'][repeat['dimension'].index()]"></span>
         </div>
     </tal:dimensions>
-</span>
-
-<span metal:define-macro="price_display"  tal:omit-tag="">
-
 </span>

--- a/ftw/shop/browser/templates/listing/macros.pt
+++ b/ftw/shop/browser/templates/listing/macros.pt
@@ -4,7 +4,7 @@
             <label tal:content="dimension"></label>
             <input
                     type="text"
-                    size="3"
+                    size="5"
                     tal:attributes="name python: 'dimension:float' if not 'skuCode' in locals() else 'dimension_%s' % skuCode;
                                     value python:'' if not item.get('dimensions') else item['dimensions'][repeat['dimension'].index];" />
         </span>

--- a/ftw/shop/browser/templates/listing/macros.pt
+++ b/ftw/shop/browser/templates/listing/macros.pt
@@ -20,3 +20,7 @@
         </div>
     </tal:dimensions>
 </span>
+
+<span metal:define-macro="price_display"  tal:omit-tag="">
+
+</span>

--- a/ftw/shop/browser/templates/mail/order_confirmation.pt
+++ b/ftw/shop/browser/templates/mail/order_confirmation.pt
@@ -100,8 +100,8 @@ Thank you for your order in our shop on the
        <th i18n:translate="label_article_no">Article number</th>
        <th i18n:translate="cart_header_product">Product</th>
        <th tal:condition="has_order_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price per item</th>
        <th i18n:translate="cart_header_quantity">Quantity</th>
-       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price</th>
        <th tal:condition="show_prices" i18n:translate="cart_header_total">Total</th>
    </tr>
  </thead>
@@ -111,8 +111,8 @@ Thank you for your order in our shop on the
      <td tal:content="item/sku_code"/>
      <td tal:content="item/title"/>
      <td tal:condition="has_order_dimensions"><span metal:use-macro="context/@@shopitem_macros/dimensions_display"></span></td>
+     <td tal:condition="show_prices" tal:content="item/price_per_item"/>
      <td tal:content="item/quantity"/>
-     <td tal:condition="show_prices" tal:content="python:str(item.getPrice()) in ('0.00', '0.0') and ' ' or str(item.getPrice())"/>
      <td tal:condition="show_prices" tal:content="item/getTotal"/>
    </tr>
  </tbody>

--- a/ftw/shop/browser/templates/mail/order_notification.pt
+++ b/ftw/shop/browser/templates/mail/order_notification.pt
@@ -102,8 +102,8 @@
        <th i18n:translate="label_article_no">Article number</th>
        <th i18n:translate="cart_header_product">Product</th>
        <th tal:condition="has_order_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price per item</th>
        <th i18n:translate="cart_header_quantity">Quantity</th>
-       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price</th>
        <th tal:condition="show_prices" i18n:translate="cart_header_total">Total</th>
    </tr>
   </thead>
@@ -113,8 +113,8 @@
      <td tal:content="item/sku_code"/>
      <td tal:content="item/title"/>
      <td tal:condition="has_order_dimensions"><span metal:use-macro="context/@@shopitem_macros/dimensions_display"></span></td>
+     <td tal:condition="show_prices" tal:content="item/price_per_item"/>
      <td tal:content="item/quantity"/>
-     <td tal:condition="show_prices" tal:content="python:str(item.getPrice()) in ('0.00', '0.0') and ' ' or str(item.getPrice())"/>
      <td tal:condition="show_prices" tal:content="item/getTotal"/>
    </tr>
   </tbody>

--- a/ftw/shop/browser/templates/mail/supplier_notification.pt
+++ b/ftw/shop/browser/templates/mail/supplier_notification.pt
@@ -96,8 +96,8 @@
        <th i18n:translate="label_article_no">Article number</th>
        <th i18n:translate="cart_header_product">Product</th>
        <th tal:condition="has_order_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price per item</th>
        <th i18n:translate="cart_header_quantity">Quantity</th>
-       <th tal:condition="show_prices" i18n:translate="cart_header_price">Price</th>
        <th tal:condition="show_prices" i18n:translate="cart_header_total">Total</th>
    </tr>
 
@@ -105,8 +105,8 @@
      <td tal:content="item/sku_code"/>
      <td tal:content="item/title"/>
      <td tal:condition="has_order_dimensions"><span metal:use-macro="context/@@shopitem_macros/dimensions_display"></span></td>
+     <td tal:condition="show_prices" tal:content="item/price_per_item"/>
      <td tal:content="item/quantity"/>
-     <td tal:condition="show_prices" tal:content="python:str(item.getPrice()) in ('0.00', '0.0') and ' ' or str(item.getPrice())"/>
      <td tal:condition="show_prices" tal:content="item/getTotal"/>
    </tr>
 

--- a/ftw/shop/browser/templates/order_view.pt
+++ b/ftw/shop/browser/templates/order_view.pt
@@ -100,8 +100,8 @@
           <tr>
             <th i18n:translate="cart_header_product">Product</th>
             <th tal:condition="view/has_order_dimensions" i18n:translate="cart_header_dimensions">Dimensions</th>
+            <th i18n:translate="cart_header_price">Price per item</th>
             <th i18n:translate="cart_header_quantity">Quantity</th>
-            <th i18n:translate="cart_header_price">Price</th>
             <th i18n:translate="cart_header_total">Total</th>
           </tr>
         </thead>
@@ -110,8 +110,8 @@
             <tr>
               <td tal:content="item/title"></td>
               <td tal:condition="view/has_order_dimensions"><span metal:use-macro="context/@@shopitem_macros/dimensions_display"></span></td>
+              <td tal:content="item/price_per_item"></td>
               <td tal:content="item/quantity"></td>
-              <td tal:content="item/getPrice"></td>
               <td tal:content="item/getTotal"></td>
             </tr>
           </metal:block>

--- a/ftw/shop/btree_storage.py
+++ b/ftw/shop/btree_storage.py
@@ -101,6 +101,7 @@ class CartItems(Persistent):
         self.vat_amount = None
         self.dimensions = None
         self.selectable_dimensions = None
+        self.price_per_item = None
 
         self.order = None
 
@@ -186,6 +187,7 @@ class BTreeOrderStorage(Persistent):
             cart_items.vat_amount = Decimal(cart_data[key]['vat_amount'])
             cart_items.dimensions = cart_data[key]['dimensions']
             cart_items.selectable_dimensions = cart_data[key]['selectable_dimensions']
+            cart_items.price_per_item = cart_data[key]['price_per_item']
             cart_items.order_id = order_id
             cart_items.order = new_order
 

--- a/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/de/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ftw.shop\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: 2015-01-22 09:06+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -49,7 +49,7 @@ msgstr "Kategorien"
 msgid "Change status"
 msgstr "Status ändern"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr "Bestellen"
 
@@ -69,7 +69,7 @@ msgstr "Anzeigemodus"
 msgid "Edit Shopping Cart portlet"
 msgstr "Warenkorb-Portlet bearbeiten"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr "Warenkorb leeren"
 
@@ -81,7 +81,7 @@ msgstr "Anzeigen"
 msgid "Length (m)"
 msgstr "Länge (m)"
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr "Länge (mm)"
 
@@ -111,7 +111,7 @@ msgstr "Shop-Artikel"
 msgid "Supplier"
 msgstr "Lieferant"
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr "Dicke (mm)"
 
@@ -131,7 +131,7 @@ msgstr "Dieses Portlet zeigt den Warenkorb an."
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr "Warenkorb aktualisieren"
 
@@ -147,15 +147,15 @@ msgstr ""
 msgid "Variations"
 msgstr "Variationen"
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr "Gramm (g)"
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr "Gewicht (kg)"
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr "Breite (mm)"
 
@@ -188,35 +188,35 @@ msgstr "Beschreibung"
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr "Abmessung"
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
-msgstr "Preis"
+msgstr "Preis pro Stück"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr "Produkt"
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr "Menge"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -246,42 +246,42 @@ msgstr "Titel"
 msgid "categories_title"
 msgstr "Kategorien"
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -292,18 +292,18 @@ msgid "desc_vat_rate"
 msgstr ""
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 #, fuzzy
 msgid "description_dimensions"
 msgstr "Definiert welche Abmessungen am Produkt vom Kunden gewählt werden können. Der Preis wird pro Einheit (mm, mm³, etc.) angebeben."
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr "Die Mengeneinheit in der das Produkt gemessen wird."
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr "%(label)s (%(dimension)s) - Preis in %(price)s"
 
@@ -317,9 +317,9 @@ msgid "header_orderdetails"
 msgstr "Einzelheiten zu Ihrer Bestellung"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr "Bestellte Artikel"
 
@@ -442,14 +442,14 @@ msgid "label_any_status"
 msgstr "Alle"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr "Artikel-Nr."
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr "Text"
 
@@ -548,9 +548,9 @@ msgid "label_description"
 msgstr "Beschreibung"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr "Bemerkungen"
 
@@ -580,7 +580,7 @@ msgstr "Variationen bearbeiten"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-Mail"
@@ -601,14 +601,14 @@ msgid "label_from_date"
 msgstr "Von:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr "Bild"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr "MwSt"
 
@@ -618,7 +618,7 @@ msgid "label_l_w"
 msgstr "Länge, Breite"
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr "Länge, Breite, Dicke"
 
@@ -628,7 +628,7 @@ msgid "label_lastname"
 msgstr "Nachname"
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr "Länge"
 
@@ -658,7 +658,7 @@ msgid "label_name"
 msgstr "Name"
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr "Neues Attribut"
 
@@ -673,17 +673,17 @@ msgid "label_new_value"
 msgstr "Neuer Wert"
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr "Neuer Wert 1"
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr "Neuer Wert 2"
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr "Persönliche Informationen"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Tel."
@@ -769,7 +769,7 @@ msgid "label_save"
 msgstr "Speichern"
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr "Abmessung"
 
@@ -804,7 +804,7 @@ msgid "label_shop_name"
 msgstr "Geben sie den Shop-Namen ein"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Preis anzeigen"
@@ -854,7 +854,7 @@ msgstr "Übersicht"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr "Lieferant"
 
@@ -869,7 +869,7 @@ msgid "label_supplier_email"
 msgstr "E-Mail"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr "Lieferant aus übergeordneter Kategorie"
 
@@ -901,25 +901,25 @@ msgid "label_used"
 msgstr "Abweichende Lieferadresse"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Variations-Attribut 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Werte für Variation 1"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Variations-Attribut 2"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Werte für Variation 2"
@@ -955,7 +955,7 @@ msgid "label_vat_rates"
 msgstr "MwSt-Sätze"
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr "Gewicht"
 
@@ -968,17 +968,17 @@ msgid "link_agb"
 msgstr "http://www.4teamwork.ch"
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr "Der Warenkorb wurde geleert."
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr "Ungültige Mengenangabe. Der Warenkorb wurde nicht aktualisiert."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr "Der Warenkorb wurde aktualisiert."
 
@@ -994,32 +994,32 @@ msgid "msg_external_redirect"
 msgstr "Sie werden nun auf eine externe Seite des Zahlungsanbieters weitergeleitet"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr "Ungültige Abmessung."
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr "Der Artikel wurde in den Warenkorb gelegt."
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr "Artikel ist deaktiviert und kann nicht hinzugefügt werden"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr "Fehler"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr "Information"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr "Weiterfahren mit leeren Warenkorb nicht möglich"
 
@@ -1151,19 +1151,19 @@ msgid "title_personal_information"
 msgstr "Adressangaben"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr "Lieferadresse"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 msgid "txt_contact"
 msgstr "Bei Fragen kontaktieren Sie uns bitte: ${phone} E-Mail ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr ""
 
@@ -1173,9 +1173,9 @@ msgid "txt_ordernumber"
 msgstr "Ihre Bestellnummer lautet"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr "Verpackung und Versandkosten sind nicht enthalten und werden individuell verrechnet."
 
@@ -1202,9 +1202,9 @@ msgid "txt_title"
 msgstr "Sehr geehrte/r"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 msgid "txt_total"
 msgstr "Total (inkl. MwSt)"
 

--- a/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/es/LC_MESSAGES/ftw.shop.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: Enny Rodriguez <administrador@femto.com.ve>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,7 +50,7 @@ msgstr "Categorías"
 msgid "Change status"
 msgstr "Cambiar estado"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr "Pedido"
 
@@ -70,7 +70,7 @@ msgstr "Visualización"
 msgid "Edit Shopping Cart portlet"
 msgstr "Editar porlet de carrito de compra"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr "Limpiar carrito de compra"
 
@@ -82,7 +82,7 @@ msgstr "Filtro"
 msgid "Length (m)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr "Artículo"
 msgid "Supplier"
 msgstr "Proveedor"
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr ""
 
@@ -132,7 +132,7 @@ msgstr "Este porlet visualiza el carrito de compra"
 msgid "Update"
 msgstr "Actualizar"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr "Actualizar carrito"
 
@@ -148,15 +148,15 @@ msgstr ""
 msgid "Variations"
 msgstr "Variaciones de producto"
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr ""
 
@@ -189,35 +189,35 @@ msgstr "Descripción"
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr ""
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
-msgstr "Precio"
+msgstr "Precio por pieza"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr "Producto"
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr "Cantidad"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -247,42 +247,42 @@ msgstr "Título"
 msgid "categories_title"
 msgstr "Categorías"
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr "Descuento"
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr "Mostrar precio"
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr "Código"
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr "Proveedor"
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr "Atributo"
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr "Valor"
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr "Atributo"
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr "Valor"
@@ -293,17 +293,17 @@ msgid "desc_vat_rate"
 msgstr "Por favor, seleccione el tipo de impuesto al valor agregado por este producto."
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr ""
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr ""
 
@@ -317,9 +317,9 @@ msgid "header_orderdetails"
 msgstr "Detalles de su orden"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr "Productos pedidos"
 
@@ -442,14 +442,14 @@ msgid "label_any_status"
 msgstr "Cualquier estado"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr "Número de artículo"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr "Texto del cuerpo"
 
@@ -548,9 +548,9 @@ msgid "label_description"
 msgstr "Descripción"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr "Comentarios"
 
@@ -580,7 +580,7 @@ msgstr "Editar variaciones"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "Correo electrónico"
@@ -601,14 +601,14 @@ msgid "label_from_date"
 msgstr "De:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr "Imagen"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr "I.V.A"
 
@@ -618,7 +618,7 @@ msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgid "label_lastname"
 msgstr "Apellido"
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "label_name"
 msgstr "Nombre"
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr ""
 
@@ -673,17 +673,17 @@ msgid "label_new_value"
 msgstr ""
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr ""
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr "Información de pago"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Teléfono"
@@ -769,7 +769,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgid "label_shop_name"
 msgstr "Ingrese el nombre de la tienda"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Mostrar precio"
@@ -854,7 +854,7 @@ msgstr "Resumen"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr "Proveedor"
 
@@ -869,7 +869,7 @@ msgid "label_supplier_email"
 msgstr "Dirección"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr "Proveedor de la categoría padre"
 
@@ -901,25 +901,25 @@ msgid "label_used"
 msgstr "Diferente a la dirección de la factura"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Atributo variación 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Variación 1 valores"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Variación 2 atributos"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Variación 2 valores"
@@ -955,7 +955,7 @@ msgid "label_vat_rates"
 msgstr "I.V.A Tasas"
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgid "link_agb"
 msgstr ""
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr "Se ha limpiado el carrito"
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr "Valores especificados no válidos. Carrito no actualizado."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr "Carrito actualizado"
 
@@ -994,32 +994,32 @@ msgid "msg_external_redirect"
 msgstr "serás redirigido a un sitio externo"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr "Producto añadido al carrito"
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr "Producto deshabilitado. No puede ser añadido"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr "Error"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr "Información"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr "No se puede continuar con el carrito vacío"
 
@@ -1151,19 +1151,19 @@ msgid "title_personal_information"
 msgstr "Información personal"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr "Dirección de envío"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 msgid "txt_contact"
 msgstr "Para consultas por favor póngase en contacto con nosotros  ${phone} E-Mail ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr "Teléfono"
 
@@ -1173,9 +1173,9 @@ msgid "txt_ordernumber"
 msgstr "Tu número de orden es"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr "Costos de envío y embalaje no están incluidos y se cobrarán por separado."
 
@@ -1202,9 +1202,9 @@ msgid "txt_title"
 msgstr "Estimado"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 msgid "txt_total"
 msgstr "Total + I.V.A"
 

--- a/ftw/shop/locales/eu/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/eu/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: ftw.shop\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: 2015-01-22 09:08+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -49,7 +49,7 @@ msgstr "Kategoriak"
 msgid "Change status"
 msgstr "Egoera aldatu"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr "Ordaindu"
 
@@ -69,7 +69,7 @@ msgstr "Erakusteko modua"
 msgid "Edit Shopping Cart portlet"
 msgstr "Erosketa saskiaren portleta editatu"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr "Saskia hustu"
 
@@ -81,7 +81,7 @@ msgstr "Filtroa"
 msgid "Length (m)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr ""
 
@@ -111,7 +111,7 @@ msgstr "Erosgaia"
 msgid "Supplier"
 msgstr "Hornitzailea"
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr ""
 
@@ -131,7 +131,7 @@ msgstr "Portlet honek erosketa saskia erakusten du."
 msgid "Update"
 msgstr "Eguneratu"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr "Saskia eguneratu"
 
@@ -147,15 +147,15 @@ msgstr ""
 msgid "Variations"
 msgstr "Aldakiak"
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr ""
 
@@ -188,35 +188,35 @@ msgstr "Deskribapena"
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr ""
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
-msgstr "Prezioa"
+msgstr "Pieza prezioa"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr "Produktua"
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr "Kopurua"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr "Guztira"
 
@@ -246,42 +246,42 @@ msgstr "Izena"
 msgid "categories_title"
 msgstr "Kategoriak"
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -292,17 +292,17 @@ msgid "desc_vat_rate"
 msgstr "Aukeratu elementu honi dagokion BEZa"
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr ""
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr ""
 
@@ -316,9 +316,9 @@ msgid "header_orderdetails"
 msgstr "Zure eskariaren xehetasunak"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr "Eskatutako produktuak"
 
@@ -441,14 +441,14 @@ msgid "label_any_status"
 msgstr "Edozein egoera"
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr "Erosgai-kodea (SKU)"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr "Testua"
 
@@ -547,9 +547,9 @@ msgid "label_description"
 msgstr "Deskribapena"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr "Komentarioak"
 
@@ -579,7 +579,7 @@ msgstr "Aldakiak aldatu"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-posta"
@@ -600,14 +600,14 @@ msgid "label_from_date"
 msgstr "Noiztik:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr "Irudia"
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr "BEZ"
 
@@ -617,7 +617,7 @@ msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgid "label_lastname"
 msgstr "Abizena"
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr ""
 
@@ -657,7 +657,7 @@ msgid "label_name"
 msgstr "Izena"
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr "Atributu berria"
 
@@ -672,17 +672,17 @@ msgid "label_new_value"
 msgstr "Balio berria"
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr "Balio berria 1"
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr "Balio berria 2"
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr "Informazio pertsonala"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Telefonoa"
@@ -768,7 +768,7 @@ msgid "label_save"
 msgstr "Gorde"
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgid "label_shop_name"
 msgstr "Dendaren izena"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr "Prezioa erakutsi"
@@ -853,7 +853,7 @@ msgstr "Laburpena"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr "Hornitzailea"
 
@@ -868,7 +868,7 @@ msgid "label_supplier_email"
 msgstr "E-posta"
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr "Kategoria gurasoko hornitzailea"
 
@@ -900,25 +900,25 @@ msgid "label_used"
 msgstr "Fakturazio helbidearen ezberdina erabili"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "1. aldakiaren atributu-izena"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "1. aldakiaren balioa"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "2. aldakiaren atributu-izena"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "2. aldakiaren balioa"
@@ -954,7 +954,7 @@ msgid "label_vat_rates"
 msgstr "BEZ ehunekoak"
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr ""
 
@@ -967,17 +967,17 @@ msgid "link_agb"
 msgstr ""
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr "Saskia hustu egin da."
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr "Balioak ez dira zuzenak. Saskia ez da eguneratu."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr "Saskia eguneratu egin da."
 
@@ -993,32 +993,32 @@ msgid "msg_external_redirect"
 msgstr "Orain, kanpoko webgune batera bideratuko zaitugu ordainketa gauzatzeko."
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr "Erosgaia saskian sartu duzu."
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr "Erosgaia desaktibatuta dago eta ezin da gehitu."
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr "Errorea"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr "Informazioa"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr "Ezin da jarraitu saskia hutsik badago."
 
@@ -1150,19 +1150,19 @@ msgid "title_personal_information"
 msgstr "Informazioa"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr "Bidalketa-helbidea"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 msgid "txt_contact"
 msgstr "Eskaerak edo galderak badituzu, jarri kontaktuan gurekin. Telefonoa ${phone} E-posta ${email}"
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr "Telefonoa"
 
@@ -1172,9 +1172,9 @@ msgid "txt_ordernumber"
 msgstr "Zure eskaera zenbakia hau da"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr "Bidalketa gastuak ez daude sartuta eta aparte kobratuko dira."
 
@@ -1201,9 +1201,9 @@ msgid "txt_title"
 msgstr "Kaixo "
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 msgid "txt_total"
 msgstr "Guztira (BEZ barne)"
 

--- a/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/fr/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -49,7 +49,7 @@ msgstr "Catégories"
 msgid "Change status"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr "Commander"
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Edit Shopping Cart portlet"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr "Vider votre panier"
 
@@ -81,7 +81,7 @@ msgstr "Filtre"
 msgid "Length (m)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr "Article boutique"
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Update"
 msgstr "Actualiser"
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr "Actualiser le panier"
 
@@ -149,15 +149,15 @@ msgstr ""
 msgid "Variations"
 msgstr "Variations"
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr ""
 
@@ -190,35 +190,35 @@ msgstr "Description"
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr ""
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
-msgstr "Prix"
+msgstr "Prix par pièce"
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr "Produit"
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr "Quantité"
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr "Total"
 
@@ -248,42 +248,42 @@ msgstr "Title"
 msgid "categories_title"
 msgstr "Catégories"
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -294,17 +294,17 @@ msgid "desc_vat_rate"
 msgstr ""
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr ""
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr ""
 
@@ -318,9 +318,9 @@ msgid "header_orderdetails"
 msgstr "Détails de votre commande"
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr "Articles commandés"
 
@@ -443,14 +443,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr "Numméro de commande"
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr ""
 
@@ -549,9 +549,9 @@ msgid "label_description"
 msgstr "Description"
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr "Remarques"
 
@@ -582,7 +582,7 @@ msgstr "Modifier les variations"
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr "E-mail"
@@ -603,14 +603,14 @@ msgid "label_from_date"
 msgstr "De:"
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr ""
 
@@ -620,7 +620,7 @@ msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgid "label_lastname"
 msgstr "Nom"
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgid "label_name"
 msgstr ""
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr ""
 
@@ -675,17 +675,17 @@ msgid "label_new_value"
 msgstr ""
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr ""
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr "Information personelle"
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr "Tél."
@@ -771,7 +771,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgid "label_shop_name"
 msgstr "Entree le nom boutique"
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -857,7 +857,7 @@ msgstr "Aperçu"
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr ""
 
@@ -872,7 +872,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -904,25 +904,25 @@ msgid "label_used"
 msgstr "Adresse differe livraison"
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr "Attribute variation 1"
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr "Value attribute variation 1"
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr "Attribtue variation 2"
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr "Value attribute variation 2"
@@ -958,7 +958,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr ""
 
@@ -971,17 +971,17 @@ msgid "link_agb"
 msgstr "http://www.amnesty.ch/fr/contacts/impressum/questions-legales/conditions-d-achat-en-ligne/"
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr "Le panier a été vidé"
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr "Nombre non valable. Le panier n'a pas été actualisé."
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr "Le panier a été actualisé."
 
@@ -997,32 +997,32 @@ msgid "msg_external_redirect"
 msgstr "Vous serez redirigé vers un site externe du fournisseur de paiement"
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr "L'article a été mis dans le panier"
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr "Article disabled. Pas possible d'ajouter"
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr "Erreur"
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr "Information"
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr "Commande n'est pas possible avec un panier vide"
 
@@ -1155,20 +1155,20 @@ msgid "title_personal_information"
 msgstr "Mon adresse"
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr "Adresse de livraison"
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 #, fuzzy
 msgid "txt_contact"
 msgstr "Pour demandes, veuillez vous adresser à: Tél 031 307 22 22, E-mail <a href=\"mailto:webmaster@amnesty.ch\">webmaster@amnesty.ch</a> "
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr ""
 
@@ -1178,9 +1178,9 @@ msgid "txt_ordernumber"
 msgstr "Votre commande"
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr "Les frais d'emballage et d'envoi ne sont pas compris et seront facturés en sus."
 
@@ -1207,9 +1207,9 @@ msgid "txt_title"
 msgstr "Chère, cher"
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 #, fuzzy
 msgid "txt_total"
 msgstr "Total"

--- a/ftw/shop/locales/ftw.shop.pot
+++ b/ftw/shop/locales/ftw.shop.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -47,7 +47,7 @@ msgstr ""
 msgid "Change status"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr ""
 
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Edit Shopping Cart portlet"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr ""
 
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Length (m)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr ""
 
@@ -109,7 +109,7 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr ""
 
@@ -129,7 +129,7 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr ""
 
@@ -145,15 +145,15 @@ msgstr ""
 msgid "Variations"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr ""
 
@@ -186,35 +186,35 @@ msgstr ""
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr ""
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
 msgstr ""
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr ""
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr ""
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr ""
 
@@ -244,42 +244,42 @@ msgstr ""
 msgid "categories_title"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -290,17 +290,17 @@ msgid "desc_vat_rate"
 msgstr ""
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr ""
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr ""
 
@@ -314,9 +314,9 @@ msgid "header_orderdetails"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr ""
 
@@ -439,14 +439,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr ""
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr ""
 
@@ -545,9 +545,9 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr ""
 
@@ -577,7 +577,7 @@ msgstr ""
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr ""
@@ -598,14 +598,14 @@ msgid "label_from_date"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr ""
 
@@ -615,7 +615,7 @@ msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr ""
 
@@ -625,7 +625,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr ""
 
@@ -655,7 +655,7 @@ msgid "label_name"
 msgstr ""
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr ""
 
@@ -670,17 +670,17 @@ msgid "label_new_value"
 msgstr ""
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr ""
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr ""
@@ -766,7 +766,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgid "label_shop_name"
 msgstr ""
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -851,7 +851,7 @@ msgstr ""
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -898,25 +898,25 @@ msgid "label_used"
 msgstr ""
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr ""
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr ""
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr ""
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr ""
@@ -952,7 +952,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr ""
 
@@ -965,17 +965,17 @@ msgid "link_agb"
 msgstr ""
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr ""
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr ""
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr ""
 
@@ -990,32 +990,32 @@ msgid "msg_external_redirect"
 msgstr ""
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr ""
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr ""
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr ""
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr ""
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr ""
 
@@ -1147,19 +1147,19 @@ msgid "title_personal_information"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr ""
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 msgid "txt_contact"
 msgstr ""
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr ""
 
@@ -1169,9 +1169,9 @@ msgid "txt_ordernumber"
 msgstr ""
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr ""
 
@@ -1198,9 +1198,9 @@ msgid "txt_title"
 msgstr ""
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 msgid "txt_total"
 msgstr ""
 

--- a/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
+++ b/ftw/shop/locales/it/LC_MESSAGES/ftw.shop.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-05-09 07:38+0000\n"
+"POT-Creation-Date: 2018-02-27 09:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Thomas Buchberger <t.buchberger@4teamwork.ch>\n"
 "Language-Team: 4teamwork GmbH <info@4teamwork.ch>\n"
@@ -49,7 +49,7 @@ msgstr ""
 msgid "Change status"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:94
+#: ./ftw/shop/browser/templates/cart_edit.pt:93
 msgid "Checkout"
 msgstr ""
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Edit Shopping Cart portlet"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:88
+#: ./ftw/shop/browser/templates/cart_edit.pt:87
 msgid "Empty Shopping Cart"
 msgstr ""
 
@@ -81,7 +81,7 @@ msgstr ""
 msgid "Length (m)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:44
+#: ./ftw/shop/content/shopitem.py:45
 msgid "Length (mm)"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "Supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:76
+#: ./ftw/shop/content/shopitem.py:74
 msgid "Thickness (mm)"
 msgstr ""
 
@@ -133,7 +133,7 @@ msgstr ""
 msgid "Update"
 msgstr ""
 
-#: ./ftw/shop/browser/templates/cart_edit.pt:82
+#: ./ftw/shop/browser/templates/cart_edit.pt:81
 msgid "Update Cart"
 msgstr ""
 
@@ -149,15 +149,15 @@ msgstr ""
 msgid "Variations"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:92
+#: ./ftw/shop/content/shopitem.py:89
 msgid "Weight (g)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:105
+#: ./ftw/shop/content/shopitem.py:101
 msgid "Weight (kg)"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:58
+#: ./ftw/shop/content/shopitem.py:57
 msgid "Width (mm)"
 msgstr ""
 
@@ -190,35 +190,35 @@ msgstr ""
 #. Default: "Dimensions"
 #: ./ftw/shop/browser/templates/cart_edit.pt:29
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:56
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
 msgid "cart_header_dimensions"
 msgstr ""
 
-#. Default: "Price"
-#: ./ftw/shop/browser/templates/cart_edit.pt:31
+#. Default: "Price per item"
+#: ./ftw/shop/browser/templates/cart_edit.pt:30
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:58
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
 msgid "cart_header_price"
 msgstr ""
 
 #. Default: "Product"
 #: ./ftw/shop/browser/templates/cart_edit.pt:27
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:54
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:101
 msgid "cart_header_product"
 msgstr ""
 
 #. Default: "Quantity"
-#: ./ftw/shop/browser/templates/cart_edit.pt:30
+#: ./ftw/shop/browser/templates/cart_edit.pt:31
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:57
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:102
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:103
 msgid "cart_header_quantity"
 msgstr ""
 
 #. Default: "Total"
 #: ./ftw/shop/browser/templates/cart_edit.pt:32
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:59
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:104
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:105
 msgid "cart_header_total"
 msgstr ""
 
@@ -248,42 +248,42 @@ msgstr ""
 msgid "categories_title"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:150
+#: ./ftw/shop/content/shopitem.py:146
 #: ./ftw/shop/extender.py:55
 msgid "desc_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:161
+#: ./ftw/shop/content/shopitem.py:157
 #: ./ftw/shop/extender.py:65
 msgid "desc_show_price"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:171
+#: ./ftw/shop/content/shopitem.py:167
 #: ./ftw/shop/extender.py:74
 msgid "desc_sku_code"
 msgstr ""
 
 #: ./ftw/shop/content/shopcategory.py:38
-#: ./ftw/shop/content/shopitem.py:257
+#: ./ftw/shop/content/shopitem.py:253
 msgid "desc_supplier"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:210
+#: ./ftw/shop/content/shopitem.py:206
 #: ./ftw/shop/extender.py:83
 msgid "desc_variation1_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:221
+#: ./ftw/shop/content/shopitem.py:217
 #: ./ftw/shop/extender.py:93
 msgid "desc_variation1_values"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:233
+#: ./ftw/shop/content/shopitem.py:229
 #: ./ftw/shop/extender.py:104
 msgid "desc_variation2_attr"
 msgstr ""
 
-#: ./ftw/shop/content/shopitem.py:244
+#: ./ftw/shop/content/shopitem.py:240
 #: ./ftw/shop/extender.py:115
 msgid "desc_variation2_values"
 msgstr ""
@@ -294,17 +294,17 @@ msgid "desc_vat_rate"
 msgstr ""
 
 #. Default: "Specifies which dimensions of the product can be chosen by the user. The price is per base unit (mm, g, etc.)."
-#: ./ftw/shop/content/shopitem.py:195
+#: ./ftw/shop/content/shopitem.py:191
 msgid "description_dimensions"
 msgstr ""
 
 #. Default: "The unit for the product quantity."
-#: ./ftw/shop/content/shopitem.py:180
+#: ./ftw/shop/content/shopitem.py:176
 msgid "description_unit"
 msgstr ""
 
 #. Default: "%(label)s (%(dimension)s) - price in %(price)s"
-#: ./ftw/shop/vocabularies.py:201
+#: ./ftw/shop/vocabularies.py:203
 msgid "dimensions_format"
 msgstr ""
 
@@ -318,9 +318,9 @@ msgid "header_orderdetails"
 msgstr ""
 
 #. Default: "Ordered items"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:94
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:96
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:91
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:95
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:97
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:92
 msgid "header_ordereditems"
 msgstr ""
 
@@ -443,14 +443,14 @@ msgid "label_any_status"
 msgstr ""
 
 #. Default: "Article number"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:99
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:101
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:95
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:100
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:102
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:96
 msgid "label_article_no"
 msgstr ""
 
 #. Default: "Body Text"
-#: ./ftw/shop/content/shopitem.py:139
+#: ./ftw/shop/content/shopitem.py:135
 msgid "label_body_text"
 msgstr ""
 
@@ -549,9 +549,9 @@ msgid "label_description"
 msgstr ""
 
 #. Default: "Comments"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:67
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:68
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:68
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:63
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:64
 msgid "label_details_comments"
 msgstr ""
 
@@ -581,7 +581,7 @@ msgstr ""
 
 #. Default: "Email"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:21
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:55
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:56
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:56
 msgid "label_email"
 msgstr ""
@@ -602,14 +602,14 @@ msgid "label_from_date"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/shop/content/shopitem.py:116
+#: ./ftw/shop/content/shopitem.py:112
 msgid "label_image"
 msgstr ""
 
 #. Default: "VAT"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:121
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:123
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:113
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:122
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:124
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:114
 msgid "label_included_vat"
 msgstr ""
 
@@ -619,7 +619,7 @@ msgid "label_l_w"
 msgstr ""
 
 #. Default: "Length, Width, Thickness"
-#: ./ftw/shop/content/shopitem.py:70
+#: ./ftw/shop/content/shopitem.py:69
 msgid "label_l_w_t"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgid "label_lastname"
 msgstr ""
 
 #. Default: "Length"
-#: ./ftw/shop/content/shopitem.py:41
+#: ./ftw/shop/content/shopitem.py:43
 msgid "label_length"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgid "label_name"
 msgstr ""
 
 #. Default: "New attribute"
-#: ./ftw/shop/content/variations.py:288
+#: ./ftw/shop/content/variations.py:279
 msgid "label_new_attr"
 msgstr ""
 
@@ -674,17 +674,17 @@ msgid "label_new_value"
 msgstr ""
 
 #. Default: "New value 1"
-#: ./ftw/shop/content/variations.py:286
+#: ./ftw/shop/content/variations.py:277
 msgid "label_new_value_1"
 msgstr ""
 
 #. Default: "New value 2"
-#: ./ftw/shop/content/variations.py:287
+#: ./ftw/shop/content/variations.py:278
 msgid "label_new_value_2"
 msgstr ""
 
 #. Default: "---"
-#: ./ftw/shop/content/shopitem.py:36
+#: ./ftw/shop/content/shopitem.py:38
 msgid "label_no_dimensions"
 msgstr ""
 
@@ -742,7 +742,7 @@ msgstr ""
 
 #. Default: "Phone"
 #: ./ftw/shop/browser/templates/checkout/order_review.pt:22
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:59
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:60
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:60
 msgid "label_phone"
 msgstr ""
@@ -770,7 +770,7 @@ msgid "label_save"
 msgstr ""
 
 #. Default: "Selectable dimensions"
-#: ./ftw/shop/content/shopitem.py:193
+#: ./ftw/shop/content/shopitem.py:189
 msgid "label_selectable_dimensions"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgid "label_shop_name"
 msgstr ""
 
 #. Default: "Show price"
-#: ./ftw/shop/content/shopitem.py:160
+#: ./ftw/shop/content/shopitem.py:156
 #: ./ftw/shop/extender.py:64
 msgid "label_show_price"
 msgstr ""
@@ -855,7 +855,7 @@ msgstr ""
 #. Default: "Supplier"
 #: ./ftw/shop/browser/templates/order_manager.pt:50
 #: ./ftw/shop/content/shopcategory.py:37
-#: ./ftw/shop/content/shopitem.py:256
+#: ./ftw/shop/content/shopitem.py:252
 msgid "label_supplier"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgid "label_supplier_email"
 msgstr ""
 
 #. Default: "Supplier from parent category"
-#: ./ftw/shop/vocabularies.py:186
+#: ./ftw/shop/vocabularies.py:187
 msgid "label_supplier_from_parent"
 msgstr ""
 
@@ -902,25 +902,25 @@ msgid "label_used"
 msgstr ""
 
 #. Default: "Variation 1 Attribute"
-#: ./ftw/shop/content/shopitem.py:208
+#: ./ftw/shop/content/shopitem.py:204
 #: ./ftw/shop/extender.py:81
 msgid "label_variation1_attr"
 msgstr ""
 
 #. Default: "Variation 1 Values"
-#: ./ftw/shop/content/shopitem.py:219
+#: ./ftw/shop/content/shopitem.py:215
 #: ./ftw/shop/extender.py:91
 msgid "label_variation1_values"
 msgstr ""
 
 #. Default: "Variation 2 Attribute"
-#: ./ftw/shop/content/shopitem.py:231
+#: ./ftw/shop/content/shopitem.py:227
 #: ./ftw/shop/extender.py:102
 msgid "label_variation2_attr"
 msgstr ""
 
 #. Default: "Variation 2 Values"
-#: ./ftw/shop/content/shopitem.py:242
+#: ./ftw/shop/content/shopitem.py:238
 #: ./ftw/shop/extender.py:113
 msgid "label_variation2_values"
 msgstr ""
@@ -956,7 +956,7 @@ msgid "label_vat_rates"
 msgstr ""
 
 #. Default: "Weight"
-#: ./ftw/shop/content/shopitem.py:89
+#: ./ftw/shop/content/shopitem.py:87
 msgid "label_weight"
 msgstr ""
 
@@ -969,17 +969,17 @@ msgid "link_agb"
 msgstr ""
 
 #. Default: "Cart emptied."
-#: ./ftw/shop/browser/cart.py:331
+#: ./ftw/shop/browser/cart.py:384
 msgid "msg_cart_emptied"
 msgstr ""
 
 #. Default: "Invalid Values specified. Cart not updated."
-#: ./ftw/shop/browser/cart.py:353
+#: ./ftw/shop/browser/cart.py:405
 msgid "msg_cart_invalidvalue"
 msgstr ""
 
 #. Default: "Cart updated."
-#: ./ftw/shop/browser/cart.py:316
+#: ./ftw/shop/browser/cart.py:369
 msgid "msg_cart_updated"
 msgstr ""
 
@@ -994,32 +994,32 @@ msgid "msg_external_redirect"
 msgstr ""
 
 #. Default: "Invalid dimensions."
-#: ./ftw/shop/browser/cart.py:425
+#: ./ftw/shop/browser/cart.py:500
 msgid "msg_invalid_dimensions"
 msgstr ""
 
 #. Default: "Added item to cart."
-#: ./ftw/shop/browser/cart.py:284
+#: ./ftw/shop/browser/cart.py:337
 msgid "msg_item_added"
 msgstr ""
 
 #. Default: "Item is disabled and can't be added."
-#: ./ftw/shop/browser/cart.py:287
+#: ./ftw/shop/browser/cart.py:340
 msgid "msg_item_disabled"
 msgstr ""
 
 #. Default: "Error"
-#: ./ftw/shop/browser/cart.py:420
+#: ./ftw/shop/browser/cart.py:495
 msgid "msg_label_error"
 msgstr ""
 
 #. Default: "Information"
-#: ./ftw/shop/browser/cart.py:417
+#: ./ftw/shop/browser/cart.py:492
 msgid "msg_label_info"
 msgstr ""
 
 #. Default: "Can't proceed with empty cart."
-#: ./ftw/shop/browser/cart.py:511
+#: ./ftw/shop/browser/cart.py:586
 msgid "msg_no_cart"
 msgstr ""
 
@@ -1151,19 +1151,19 @@ msgid "title_personal_information"
 msgstr ""
 
 #. Default: "Shipping Address"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:71
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:72
 #: ./ftw/shop/browser/templates/mail/order_notification.pt:72
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:68
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:69
 msgid "title_shipping_address"
 msgstr ""
 
 #. Default: "For inquiries please contact us: ${phone} E-Mail ${email}"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:153
 msgid "txt_contact"
 msgstr ""
 
 #. Default: "Phone"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:147
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:150
 msgid "txt_contact_phone"
 msgstr ""
 
@@ -1173,9 +1173,9 @@ msgid "txt_ordernumber"
 msgstr ""
 
 #. Default: "Shipping and packaging costs are not included and will be charged individually."
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:142
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:143
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:132
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:145
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:146
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:135
 msgid "txt_shipping"
 msgstr ""
 
@@ -1202,9 +1202,9 @@ msgid "txt_title"
 msgstr ""
 
 #. Default: "Total (incl.VAT)"
-#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:129
-#: ./ftw/shop/browser/templates/mail/order_notification.pt:131
-#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:121
+#: ./ftw/shop/browser/templates/mail/order_confirmation.pt:131
+#: ./ftw/shop/browser/templates/mail/order_notification.pt:133
+#: ./ftw/shop/browser/templates/mail/supplier_notification.pt:123
 msgid "txt_total"
 msgstr ""
 

--- a/ftw/shop/profiles/default/jsregistry.xml
+++ b/ftw/shop/profiles/default/jsregistry.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
-<javascript cacheable="True" compression="none" cookable="True"
-            enabled="True" expression="" id="++resource++ftw-shop-resources/shop_config.js" inline="False"/>
+  <javascript cacheable="True" compression="none" cookable="True"
+              enabled="True" expression="" id="++resource++ftw-shop-resources/shop_config.js" inline="False"/>
+  <javascript cacheable="True" compression="none" cookable="True"
+              enabled="True" expression="" id="++resource++ftw-shop-resources/shop_price_calculation.js"
+              inline="False" insert-after="++resource++plone.app.jquery.js"/>
 </object>

--- a/ftw/shop/tests/base.py
+++ b/ftw/shop/tests/base.py
@@ -60,12 +60,13 @@ MOCK_CART = {'some-uid': {'description': 'A Shop Item with no variations',
                           'supplier_email': 'supplier@example.org',
                           'supplier_name': 'Supplier Name',
                           'title': 'Item Title',
-                          'total': '8.30',
+                          'total': '16.60',
                           'url': 'http://nohost/plone/shop/products/item',
                           'vat_amount': '0.00',
                           'vat_rate': Decimal('0.00'),
-                          'dimensions': [1],
-                          'selectable_dimensions': [u'Weight (g)']}}
+                          'dimensions': [2],
+                          'selectable_dimensions': [u'Weight (g)'],
+                          'price_per_item': '8.30'}}
 
 MOCK_CART_TWO_SUPPLIERS = {
     'other-uid': {'description': 'A Shop Item with no variations',
@@ -81,7 +82,8 @@ MOCK_CART_TWO_SUPPLIERS = {
                   'vat_amount': '0.00',
                   'vat_rate': Decimal('0.00'),
                   'dimensions': [],
-                  'selectable_dimensions': []}}
+                  'selectable_dimensions': [],
+                  'price_per_item': '8.30'}}
 
 
 class FakeMailHostAdapter(MailHostAdapter):

--- a/ftw/shop/tests/test_browser_checkout.py
+++ b/ftw/shop/tests/test_browser_checkout.py
@@ -184,7 +184,7 @@ class TestBrowserCheckout(TestCase):
         self.assertEquals([{'Product': 'Socks',
                             'Description': 'A good pair of socks.',
                             'Quantity': '1',
-                            'Price': '10.00',
+                            'Price per item': '10.00',
                             'Total': '10.00'}],
                           browser.css('table.cartListing').first.dicts(foot=False))
 

--- a/ftw/shop/tests/test_cart.py
+++ b/ftw/shop/tests/test_cart.py
@@ -23,6 +23,7 @@ class TestCart(FtwShopTestCase):
         self.assertEquals(len(cart_items), 1)
         item_key = self.movie.UID() + '==1-2'
         self.assertEquals(cart_items[item_key]['price'], '7.15')
+        self.assertEquals(cart_items[item_key]['price_per_item'], '14.30')
         self.assertEquals(cart_items[item_key]['total'], '28.60')
         self.assertEquals(cart_items[item_key]['skucode'], '12345')
         self.assertEquals(cart_items[item_key]['quantity'], 2)
@@ -44,6 +45,7 @@ class TestCart(FtwShopTestCase):
         item_key = "%s=var-Paperback=" % self.book.UID()
 
         self.assertEquals(cart_items[item_key]['price'], '2.00')
+        self.assertEquals(cart_items[item_key]['price_per_item'], '2.00')
         self.assertEquals(cart_items[item_key]['total'], '6.00')
         self.assertEquals(cart_items[item_key]['skucode'], 'b22')
         self.assertEquals(cart_items[item_key]['quantity'], 3)
@@ -65,6 +67,7 @@ class TestCart(FtwShopTestCase):
         self.assertEquals(len(cart_items), 3)
         item_key = "%s=var-Green-M=" % self.tshirt.UID()
         self.assertEquals(cart_items[item_key]['price'], '5.00')
+        self.assertEquals(cart_items[item_key]['price_per_item'], '5.00')
         self.assertEquals(cart_items[item_key]['total'], '20.00')
         self.assertEquals(cart_items[item_key]['skucode'], '55')
         self.assertEquals(cart_items[item_key]['quantity'], 4)
@@ -126,9 +129,11 @@ class TestCart(FtwShopTestCase):
         cart = getMultiAdapter((self.movie, self.portal.REQUEST), name='cart_view')
         cart.addtocart(skuCode='12345', quantity=1, dimension=[Decimal(1), Decimal(2)])
         movie_key = self.movie.UID()+'==1-2'
-        cart.update_item(movie_key, 2, [1, 2])
+        cart.update_item(movie_key, 2, [2, 2])
+        movie_key = self.movie.UID() + '==2-2'
         self.assertEquals(cart.cart_items()[movie_key]['quantity'], 2)
-        self.assertEquals(cart.cart_items()[movie_key]['total'], '28.60')
+        self.assertEquals(cart.cart_items()[movie_key]['price_per_item'], '28.60')
+        self.assertEquals(cart.cart_items()[movie_key]['total'], '57.20')
 
     def test_cart_update(self):
         ptool = getToolByName(self.portal, 'plone_utils')

--- a/ftw/shop/tests/test_checkout_customer_mail.py
+++ b/ftw/shop/tests/test_checkout_customer_mail.py
@@ -98,7 +98,7 @@ class TestCheckoutMailToCustomer(TestCase):
 
         self.assertEquals([{'Article number': '123.1',
                             'Product': 'A pair of socks',
-                            'Price': '12.90',
+                            'Price per item': '12.90',
                             'Quantity': '1',
                             'Total': '12.90'}],
                           browser.css('table').first.dicts(foot=False))

--- a/ftw/shop/tests/test_checkout_shopowner_mail.py
+++ b/ftw/shop/tests/test_checkout_shopowner_mail.py
@@ -114,7 +114,7 @@ class TestCheckoutMailToShopOwner(TestCase):
 
         self.assertEquals([{'Article number': '123.1',
                             'Product': 'A pair of socks',
-                            'Price': '12.90',
+                            'Price per item': '12.90',
                             'Quantity': '1',
                             'Total': '12.90'}],
                           browser.css('table').first.dicts(foot=False))

--- a/ftw/shop/tests/test_order_manager.py
+++ b/ftw/shop/tests/test_order_manager.py
@@ -111,7 +111,7 @@ class TestOrderManager(FtwShopTestCase):
             MOCK_CART['some-uid']['vat_amount'],
             MOCK_CART['some-uid']['skucode'],
             str(MOCK_CART.values()[0]['quantity']),
-            '1 Weight (g)',
+            '2 Weight (g)',
             MOCK_CART.values()[0]['title'],
             str(MOCK_CART.values()[0]['price']),
             str(MOCK_CART.values()[0]['total']),

--- a/ftw/shop/upgrades/20180227160947_add_price_calc_js/jsregistry.xml
+++ b/ftw/shop/upgrades/20180227160947_add_price_calc_js/jsregistry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+  <javascript id="++resource++ftw-shop-resources/shop_price_calculation.js"
+              insert-after="++resource++plone.app.jquery.js"
+              cacheable="True"
+              compression="none"
+              cookable="True"
+              enabled="True"
+              expression=""
+              inline="False"/>
+</object>

--- a/ftw/shop/upgrades/20180227160947_add_price_calc_js/upgrade.py
+++ b/ftw/shop/upgrades/20180227160947_add_price_calc_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPriceCalcJS(UpgradeStep):
+    """Add price calc js.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Since the introduction of dimension fields the price of an item can vary.
The price was only displayed as a total, which is a bit intransparent if multiple items are ordered.

This pr replaces the "price" column in the various listings including the cart edit view with a "price per item" column that takes dimensions into account.
Additionally the price per item is visible while changing the dimensions (with JS). This is used when the dimensions are first specified while adding the item or later while editing the cart.

![4wll4ixx1u](https://user-images.githubusercontent.com/1375745/36779365-13a69c24-1c70-11e8-8af1-ebc60519d887.gif)
![screen shot 2018-02-28 at 10 14 07](https://user-images.githubusercontent.com/1375745/36779398-2653281a-1c70-11e8-9ea7-5d471763d3b2.png)
