### PR TITLE
Fix dimensions display styling

### DIFF
--- a/ftw/shop/browser/resources/ftw_shop.css
+++ b/ftw/shop/browser/resources/ftw_shop.css
@@ -264,7 +264,11 @@ input#shipping_address-widgets-title, input#contact_information-widgets-title {
     overflow: auto;
     margin: 1px 0;
 }
-.template-cart_edit td span input,
-.template-checkout-wizard .cartListing .dimensions-display span:last-child {
+.template-cart_edit td span input {
     float: right;
+}
+
+.template-checkout-wizard .cartListing .dimensions-display {
+    white-space: nowrap;
+    display: inline-block;
 }


### PR DESCRIPTION
When the unit numbers were to long the `float: right;` didnt work no more and messed the lines up. Those changes fix that issue. Each unit will now be displayed in a separate line.