### PR TITLE
Ignore encoding errors in mail body

### DIFF
--- a/ftw/shop/mailer.py
+++ b/ftw/shop/mailer.py
@@ -38,7 +38,7 @@ class MailHostAdapter(object):
 
         try:
             # Plone 4
-            msg = message_from_string(msg_body.encode(charset))
+            msg = message_from_string(msg_body.encode(charset, 'ignore'))
             if encode is None or encode in ["quoted-printable", "qp"]:
                 encode_quopri(msg)
             else:


### PR DESCRIPTION
🚧 Currently installed on testing. 🚧 

Certain characters that can possibly be contained in the mail body can not be encoded in latin1, so we no simply ignore those encoding errors.

See -> https://extranet.4teamwork.ch/support/paedagogisches-zentrum-pz.bs/tracker/28