### PR TITLE
Add missing history entry to last commit

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore encoding errors in mail body [raphael-s]
 
 
 3.0.1 (2018-03-28)


### PR DESCRIPTION
Adds `history.txt` entry for https://github.com/4teamwork/ftw.shop/pull/75