### PR TITLE
Ignore unsupported characters while generating the csv in cp1252 (For example emojis are not in there).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Ignore unsupported characters while generating the csv in cp1252 (For example emojis are not in there). [mathias.leimgruber]
 
 
 3.0.3 (2019-11-25)

--- a/ftw/shop/browser/ordermanager.py
+++ b/ftw/shop/browser/ordermanager.py
@@ -217,7 +217,7 @@ class OrderManagerView(BrowserView):
 
             for i, value in enumerate(order_data):
                 if isinstance(value, unicode):
-                    order_data[i] = value.encode('cp1252')
+                    order_data[i] = value.encode('cp1252', 'ignore')
 
             for cart_item in order.cartitems:
                 # format dimensions


### PR DESCRIPTION
Example order:  https://shop-gestalten-pz-bs.ch/order_view/1561
Text: Gerne zum Pavillon mit den Pingpongtischen liefern. 😊

Lead to the following error, since cp1252 does not support emojis. 

``` 
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module ftw.shop.browser.ordermanager, line 138, in __call__
Module ftw.shop.browser.ordermanager, line 220, in download_csv
Module encodings.cp1252, line 12, in encode
```

This PR simply ignores this content.